### PR TITLE
[FIX] fleet, hr_fleet, account_fleet: removed useless field plan_to_change_car

### DIFF
--- a/addons/account_fleet/tests/test_account_fleet.py
+++ b/addons/account_fleet/tests/test_account_fleet.py
@@ -19,7 +19,6 @@ class TestAccountFleet(AccountTestInvoicingCommon):
         })
         car_1 = self.env["fleet.vehicle"].create({
             "model_id": model.id,
-            "plan_to_change_car": False
         })
 
         bill = self.init_invoice('in_invoice', products=self.product_a, invoice_date='2021-09-01', post=False)

--- a/addons/account_fleet/tests/test_fleet_vehicle_log.py
+++ b/addons/account_fleet/tests/test_fleet_vehicle_log.py
@@ -23,12 +23,10 @@ class TestFleetVehicleLog(AccountTestInvoicingCommon):
             {
                 "model_id": model.id,
                 "driver_id": cls.purchaser.id,
-                "plan_to_change_car": False
             },
             {
                 "model_id": model.id,
                 "driver_id": cls.purchaser.id,
-                "plan_to_change_car": False
             }
         ])
         cls.bill = cls.env['account.move'].create({
@@ -146,7 +144,6 @@ class TestFleetVehicleLog(AccountTestInvoicingCommon):
         })
         car = self.env["fleet.vehicle"].create({
             "model_id": model.id,
-            "plan_to_change_car": False
         })
 
         partner = self.env['res.partner'].create({

--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -59,10 +59,6 @@ class FleetVehicle(models.Model):
         tracking=True,
         help="Driver address of the vehicle",
     )
-    plan_to_change_car = fields.Boolean(
-        related="driver_id.plan_to_change_car", store=True,
-        readonly=False,
-    )
     mobility_card = fields.Char(
         related="driver_id.mobility_card", store=True
     )
@@ -522,8 +518,6 @@ class FleetVehicle(models.Model):
         if self.env.su:
             return su_vals
 
-        if "plan_to_change_car" in vals:
-            su_vals["plan_to_change_car"] = vals.pop("plan_to_change_car")
         return su_vals
 
     def _get_analytic_name(self):
@@ -553,8 +547,6 @@ class FleetVehicle(models.Model):
         ])
         vehicles.write({"driver_id": False})
         for vehicle in self:
-            if vehicle.vehicle_type == "car":
-                vehicle.future_driver_id.sudo().write({"plan_to_change_car": False})
             vehicle.driver_id = vehicle.future_driver_id
             vehicle.future_driver_id = False
 

--- a/addons/fleet/models/hr_employee.py
+++ b/addons/fleet/models/hr_employee.py
@@ -26,12 +26,6 @@ class Employee(models.Model):
     mobility_card = fields.Char(
         groups="fleet.fleet_group_user"
     )
-    plan_to_change_car = fields.Boolean(
-        string="Plan To Change Car",
-        default=False,
-        tracking=True,
-    )
-
 
     @api.depends("private_car_plate", "vehicle_ids.license_plate")
     def _compute_license_plate(self):

--- a/addons/fleet/tests/test_access_rights.py
+++ b/addons/fleet/tests/test_access_rights.py
@@ -18,6 +18,4 @@ class TestFleet(common.TransactionCase):
         car = self.env["fleet.vehicle"].with_user(manager).create({
             "model_id": model.id,
             "driver_id": user.partner_id.id,
-            "plan_to_change_car": False
         })
-        car.with_user(manager).plan_to_change_car = True

--- a/addons/fleet/tests/test_overdue.py
+++ b/addons/fleet/tests/test_overdue.py
@@ -21,13 +21,11 @@ class TestFleet(common.TransactionCase):
         car_1 = self.env["fleet.vehicle"].create({
             "model_id": model.id,
             "driver_id": user.partner_id.id,
-            "plan_to_change_car": False
         })
 
         car_2 = self.env["fleet.vehicle"].create({
             "model_id": model.id,
             "driver_id": user.partner_id.id,
-            "plan_to_change_car": False
         })
         Log = self.env['fleet.vehicle.log']
         Log.create({
@@ -60,7 +58,6 @@ class TestFleet(common.TransactionCase):
         car_1 = self.env["fleet.vehicle"].create({
             "model_id": model.id,
             "driver_id": user.partner_id.id,
-            "plan_to_change_car": False
         })
 
         Log = self.env['fleet.vehicle.log']

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -13,15 +13,13 @@
                 <field name="tag_ids" />
                 <field name="vehicle_properties" string="Properties" />
                 <filter name="available" string="Available"
-                    domain="['&amp;', ('future_driver_id', '=', False), '|', ('driver_id', '=', False), '&amp;', ('plan_to_change_car', '=', True), ('vehicle_type', '=', 'car')]" />
+                    domain="['&amp;', ('future_driver_id', '=', False), ('driver_id', '=', False)]" />
                 <filter name="bikes" string="Bikes"
                     domain="[('vehicle_type', '=', 'bike')]" />
                 <filter name="cars" string="Cars"
                     domain="[('vehicle_type', '=', 'car')]" />
                 <filter name="trailer_hook" string="Trailer Hook"
                     domain="[('trailer_hook', '=', True)]" />
-                <filter name="planned" string="Planned for Change"
-                    domain="[('vehicle_type', '=', 'car'), ('plan_to_change_car', '=', True)]" />
                 <separator />
                 <filter name="alert_true" string="Need Action"
                     domain="['|', ('contract_renewal_due_soon', '=', True), ('contract_renewal_overdue', '=', True)]" />
@@ -240,9 +238,6 @@
                                 widget="many2one_avatar"
                                 domain="['|', ('company_id', '=', False ), ('company_id', '=', company_id)]" />
                             <field name="future_driver_id" widget="many2one_avatar" />
-                            <field name="plan_to_change_car"
-                                invisible="vehicle_type != 'car'"
-                                groups="fleet.fleet_group_manager" />
                             <field name="manager_id"
                                 widget="many2one_avatar_user"
                                 domain="[('share', '=', False), ('company_id', '=', company_id)]" />

--- a/addons/hr_fleet/tests/test_hr_fleet_driver.py
+++ b/addons/hr_fleet/tests/test_hr_fleet_driver.py
@@ -31,12 +31,10 @@ class TestHrFleetDriver(common.TransactionCase):
         cls.car = cls.env["fleet.vehicle"].create({
             "model_id": cls.model.id,
             "future_driver_id": cls.test_employee.work_contact_id.id,
-            "plan_to_change_car": False
         })
 
         cls.car2 = cls.env["fleet.vehicle"].create({
             "model_id": cls.model.id,
-            "plan_to_change_car": False
         })
 
     def test_driver_sync_with_employee(self):

--- a/addons/hr_fleet/tests/test_mail_activity_plan.py
+++ b/addons/hr_fleet/tests/test_mail_activity_plan.py
@@ -31,7 +31,6 @@ class TestActivitySchedule(ActivityScheduleHRCase):
                     "name": "A3",
                 }).id,
                 "manager_id": cls.user_manager.id,
-                "plan_to_change_car": False,
             })
             employee.car_ids = car
 


### PR DESCRIPTION
# [task5459](https://agromarin.mx/odoo/project/22/tasks/5459)

Object `pos.config` was no uploading when open a PoS because it was reading employee fields and user had not access to `plan_to_change_car` field.

`plan_to_change_car` field is no a field used in Marin customization, by this reason it is removed in this commit