### PR TITLE
[FIX] account, purchase: some fields still needed to be renamed

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -564,7 +564,7 @@ class ResPartner(models.Model):
     )
     ref_company_ids = fields.One2many('res.company', 'partner_id',
         string='Companies that refers to partner')
-    supplier_invoice_count = fields.Integer(compute='_compute_supplier_invoice_count', string='# Vendor Bills')
+    count_supplier_invoice = fields.Integer(compute='_compute_count_supplier_invoice', string='# Vendor Bills')
     invoice_ids = fields.One2many('account.move', 'partner_id', string='Invoices', readonly=True, copy=False)
     contract_ids = fields.One2many('account.analytic.account', 'partner_id', string='Partner Contracts', readonly=True)
     bank_account_count = fields.Integer(compute='_compute_bank_count', string="Bank")
@@ -637,7 +637,7 @@ class ResPartner(models.Model):
         for partner in self:
             partner.bank_account_count = mapped_data.get(partner.id, 0)
 
-    def _compute_supplier_invoice_count(self):
+    def _compute_count_supplier_invoice(self):
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search_fetch(
             [('id', 'child_of', self.ids)],
@@ -651,11 +651,11 @@ class ResPartner(models.Model):
         )
         self_ids = set(self._ids)
 
-        self.supplier_invoice_count = 0
+        self.count_supplier_invoice = 0
         for partner, count in supplier_invoice_groups:
             while partner:
                 if partner.id in self_ids:
-                    partner.supplier_invoice_count += count
+                    partner.count_supplier_invoice += count
                 partner = partner.parent_id
 
     def _get_duplicated_bank_accounts(self):

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -169,9 +169,9 @@
                         name="%(account.res_partner_action_supplier_bills)d"
                         groups="account.group_account_invoice"
                         icon="fa-pencil-square-o" help="Vendor Bills"
-                        invisible="supplier_invoice_count == 0"
+                        invisible="count_supplier_invoice == 0"
                     >
-                        <field string="Vendor Bills" name="supplier_invoice_count" widget="statinfo"/>
+                        <field string="Vendor Bills" name="count_supplier_invoice" widget="statinfo"/>
                     </button>
                 </div>
 

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -66,7 +66,7 @@ class PurchaseOrder(models.Model):
         help="You can find a vendor by its Name, TIN, Email or Internal Reference.",
     )
     count_partner_supplier_invoice = fields.Integer(
-        related="partner_id.supplier_invoice_count"
+        related="partner_id.count_supplier_invoice"
     )
     dest_address_id = fields.Many2one(
         comodel_name="res.partner",


### PR DESCRIPTION
# [Tasks 5618](https://agromarin.mx/odoo/my-tasks/5618)

**Traceback**
![Captura de pantalla de 2025-03-03 16-00-23](https://github.com/user-attachments/assets/da399953-65f2-467d-8851-43c2acd72a56)

## Summary by Sourcery

Fixes an issue where some fields related to supplier invoice counts were not correctly renamed, leading to errors. This commit renames the fields to ensure consistency and resolves the traceback error.

Bug Fixes:
- Fixes a traceback error caused by incorrectly named fields related to supplier invoice counts.
- Renames 'supplier_invoice_count' to 'count_supplier_invoice' in the partner model and related views to ensure consistency.