### PR TITLE
[FIX] product: can't adapt Many2one field on uom_ids field

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -133,7 +133,7 @@ class ProductTemplate(models.Model):
     uom_ids = fields.Many2many(
         comodel_name="uom.uom",
         string="Packagings",
-        domain=[("id", "!=", uom_id)],
+        domain="[('id', '!=', uom_id)]",
         help="Additional packagings for this product which can be used for sales",
     )
     volume = fields.Float(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the domain of the uom_ids field to adapt correctly.