### PR TITLE
[FIX] sale, sale_*, stock_delivery: order_line to order_line_ids

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -315,7 +315,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
             # Create down payment section if necessary
             SaleOrderline = self.env["sale.order.line"].with_context(sale_no_log_for_new_lines=True)
-            if not any(line.display_type and line.is_downpayment for line in order.order_line):
+            if not any(line.display_type and line.is_downpayment for line in order.order_line_ids):
                 SaleOrderline.create(self._prepare_down_payment_section_values(order))
 
             values, accounts = self._prepare_down_payment_lines_values(order)

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -135,7 +135,7 @@ class SaleOrderDiscount(models.TransientModel):
         else:  # so_discount
             discount_percentage = self.discount_percentage
         total_price_per_tax_groups = defaultdict(float)
-        for line in self.sale_order_id.order_line:
+        for line in self.sale_order_id.order_line_ids:
             if not line.product_uom_qty or not line.price_unit:
                 continue
             discounted_price = line.price_unit * (1 - (line.discount or 0.0) / 100)

--- a/addons/sale_expense/models/sale_order.py
+++ b/addons/sale_expense/models/sale_order.py
@@ -37,4 +37,4 @@ class SaleOrder(models.Model):
     @api.depends('expense_ids')
     def _compute_expense_count(self):
         for sale_order in self:
-            sale_order.expense_count = len(sale_order.order_line.expense_ids)
+            sale_order.expense_count = len(sale_order.order_line_ids.expense_ids)

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -146,7 +146,7 @@ class SaleOrder(models.Model):
                 for fname in ['product_id', 'uom_id', 'quantity']
             )
 
-        lines = self.order_line
+        lines = self.order_line_ids
         options = self.sale_order_option_ids
         t_lines = self.sale_order_template_id.sale_order_template_line_ids
         t_options = self.sale_order_template_id.sale_order_template_option_ids

--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -120,7 +120,7 @@ class SaleOrderOption(models.Model):
             'product_uom_qty': self.quantity,
             'product_uom_id': self.uom_id.id,
             'discount': self.discount,
-            'sequence': max(self.order_id.order_line.mapped('sequence'), default=0) + 1
+            'sequence': max(self.order_id.order_line_ids.mapped('sequence'), default=0) + 1
         }
 
     @api.depends('line_id', 'order_id.order_line_ids', 'product_id')
@@ -128,7 +128,7 @@ class SaleOrderOption(models.Model):
         # NOTE: this field cannot be stored as the line_id is usually removed
         # through cascade deletion, which means the compute would be false
         for option in self:
-            option.is_present = bool(option.order_id.order_line.filtered(lambda l: l.product_id == option.product_id))
+            option.is_present = bool(option.order_id.order_line_ids.filtered(lambda l: l.product_id == option.product_id))
 
     def _search_is_present(self, operator, value):
         if (operator, value) in [('=', True), ('!=', False)]:

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -154,7 +154,7 @@ class ProjectProject(models.Model):
     def _onchange_reinvoiced_sale_order_id(self):
         if (
             not self.sale_line_id
-            and (service_sols := self.reinvoiced_sale_order_id.order_line.filtered('is_service'))
+            and (service_sols := self.reinvoiced_sale_order_id.order_line_ids.filtered('is_service'))
         ):
             self.sale_line_id = service_sols[0]
 

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -152,7 +152,7 @@ class StockPicking(models.Model):
             if product.invoice_policy == 'delivery':
                 # Check if there is already a SO line for this product to get
                 # back its unit price (in case it was manually updated).
-                so_line = sale_order.order_line.filtered(lambda sol: sol.product_id == product)
+                so_line = sale_order.order_line_ids.filtered(lambda sol: sol.product_id == product)
                 if so_line:
                     so_line_vals['price_unit'] = so_line[0].price_unit
             elif product.invoice_policy == 'order':

--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -115,7 +115,7 @@ class SaleOrderLine(models.Model):
         # dict of inverse factors for each relevant UoM found in SO
         factor_per_id = {
             uom.id: uom.factor
-            for uom in self.order_id.order_line.product_uom_id
+            for uom in self.order_id.order_line_ids.product_uom_id
         }
         # if sold as units, assume hours for time allocation
         factor_per_id[uom_unit.id] = uom_hour.factor
@@ -123,7 +123,7 @@ class SaleOrderLine(models.Model):
         allocated_hours = 0.0
         # method only called once per project, so also allocate hours for
         # all lines in SO that will share the same project
-        for line in self.order_id.order_line:
+        for line in self.order_id.order_line_ids:
             if line.is_service \
                     and line.product_id.service_tracking in ['task_in_project', 'project_only'] \
                     and line.product_id.project_template_id == self.product_id.project_template_id \

--- a/addons/sale_timesheet/wizard/project_create_invoice.py
+++ b/addons/sale_timesheet/wizard/project_create_invoice.py
@@ -43,7 +43,7 @@ class ProjectCreateInvoice(models.TransientModel):
         for wizard in self:
             amount_untaxed = 0.0
             amount_tax = 0.0
-            for line in wizard.sale_order_id.order_line.filtered(lambda sol: sol.invoice_status == 'to invoice'):
+            for line in wizard.sale_order_id.order_line_ids.filtered(lambda sol: sol.invoice_status == 'to invoice'):
                 amount_untaxed += line.price_reduce * line.qty_to_invoice
                 amount_tax += line.price_tax
             wizard.amount_to_invoice = amount_untaxed + amount_tax

--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
@@ -21,7 +21,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
     def _compute_invoicing_timesheet_enabled(self):
         for wizard in self:
             wizard.invoicing_timesheet_enabled = bool(
-                wizard.sale_order_ids.order_line.filtered(
+                wizard.sale_order_ids.order_line_ids.filtered(
                     lambda sol: sol.invoice_status == 'to invoice'
                 ).product_id.filtered(
                     lambda p: p._is_delivered_timesheet()
@@ -40,7 +40,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
         """
         if self.advance_payment_method == 'delivered' and self.invoicing_timesheet_enabled:
             if self.date_start_invoice_timesheet or self.date_end_invoice_timesheet:
-                sale_orders.order_line._recompute_qty_to_invoice(
+                sale_orders.order_line_ids._recompute_qty_to_invoice(
                     self.date_start_invoice_timesheet, self.date_end_invoice_timesheet)
 
             return sale_orders.with_context(

--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -144,7 +144,7 @@ class StockPicking(models.Model):
         self.carrier_id.get_return_label(self)
 
     def _get_matching_delivery_lines(self):
-        return self.sale_id.order_line.filtered(
+        return self.sale_id.order_line_ids.filtered(
             lambda l: l.is_delivery
             and l.currency_id.is_zero(l.price_unit)
             and l.product_id == self.carrier_id.product_id


### PR DESCRIPTION
## Summary by Sourcery

Replaces the `order_line` field by `order_line_ids` in several modules. This change ensures the correct referencing of sale order lines, especially when dealing with timesheets, invoicing, expenses, and stock deliveries.