### PR TITLE
[FIX] pos_hr: correct manager role assignment logic

### DIFF
--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -31,7 +31,7 @@ class HrEmployee(models.Model):
         bp_per_employee_id = {bp_e['id']: bp_e for bp_e in employees_barcode_pin}
 
         for employee in data:
-            if (employee['user_id'] and employee['user_id'] in manager_ids) or employee['id'] in config_id.advanced_employee_ids.ids:
+            if (employee['id'] and employee['id'] in manager_ids) or employee['id'] in config_id.advanced_employee_ids.ids:
                 role = 'manager'
             elif employee['id'] in config_id.minimal_employee_ids.ids:
                 role = 'minimal'


### PR DESCRIPTION
# [Task #6710](https://agromarin.mx/odoo/project/22/tasks/6710)

Fix the condition to assign 'manager' role by checking employee ID instead of user_id in manager_ids. This aligns with the actual filtering done earlier where manager_ids contains employee IDs.

Original condition could incorrectly assign roles when user_id was set but didn't match the manager group check.

**Caso de uso:**

1. Configurar usuario como administrador de punto de venta
2. Abrir punto de venta con usuario con una caja cerrada
3. Iniciar venta seleccionado producto
4. Cambiar precio a producto

**Comportamiento actual:**

- Aparece error que indica que "No tiene permitido cambiar precio"

**Comportamiento esperado:**

- Permitir cambio de precio

**Screenshoot**

![Captura de pantalla de 2025-04-15 15-58-09](https://github.com/user-attachments/assets/fee66841-57e7-40e1-a452-9a5d26155893)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

## Summary by Sourcery

Bug Fixes:
- Fix incorrect role assignment in POS by using employee ID for manager role check, preventing unauthorized price changes