### PR TITLE
[FIX] sale, sale_loyalty, website_sale: unexpected keyword argument 'send_email'

### DIFF
--- a/addons/sale/controllers/customer_portal.py
+++ b/addons/sale/controllers/customer_portal.py
@@ -378,7 +378,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
             return {"error": _("Invalid signature data.")}
 
         if not order_sudo._has_to_be_paid():
-            order_sudo.action_confirm(send_email=True)
+            order_sudo.with_context(send_email=True).action_confirm()
 
         pdf = (
             request.env["ir.actions.report"]

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1460,7 +1460,7 @@ class SaleOrder(models.Model):
         self.write({"state": "cancel"})
         return True
 
-    def action_confirm(self, send_email=False):
+    def action_confirm(self):
         """Confirm the given quotation(s) and set their confirmation date.
 
         If the corresponding setting is enabled, also locks the Sale Order.
@@ -1490,7 +1490,7 @@ class SaleOrder(models.Model):
                 # Public user can confirm SO, so we check the group on any record creator.
                 order.action_lock()
 
-            if send_email:
+            if self.env.context.get("send_email"):
                 order._send_order_confirmation_mail()
 
         return True

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -156,6 +156,7 @@ class SaleOrder(models.Model):
             coupon.points += change
         res = super().action_confirm()
         self._send_reward_coupon_mail()
+        self._auto_invoice_zero_amount_order()
         return res
 
     def action_cancel(self):
@@ -1424,14 +1425,14 @@ class SaleOrder(models.Model):
             coupon = apply_result.get('coupon', self.env['loyalty.card'])
         return self._get_claimable_rewards(forced_coupons=coupon)
 
-    def action_confirm(self, send_email=False):
+    def _auto_invoice_zero_amount_order(self):
         """
-        Override of sale to create invoice for zero amount order. If the order total is zero and
+        Create invoice for zero amount order. If the order total is zero and
         automatic invoicing is enabled, it creates and posts an invoice.
 
         :return: None
         """
-        super().action_confirm(send_email=send_email)
+        self.ensure_one()
         if self.amount_total or not self.reward_amount:
             return
         auto_invoice = self.env['ir.config_parameter'].get_param('sale.automatic_invoice')

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1456,7 +1456,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if not order_sudo.amount_total and not tx_sudo:
             if order_sudo.state != 'sale':
                 # Only confirm the order if it wasn't already confirmed.
-                order_sudo.action_confirm(send_email=True)
+                order_sudo.with_context(send_email=True).action_confirm()
 
             # clean context and session, then redirect to the portal page
             request.website.sale_reset()


### PR DESCRIPTION
## Summary by Sourcery

Remove the `send_email` keyword argument from `action_confirm()` method and replace it with a context-based approach for sending confirmation emails

Bug Fixes:
- Fix unexpected keyword argument issue in sale order confirmation methods across multiple modules

Enhancements:
- Refactor sale order confirmation to use context for email sending instead of a direct keyword argument
- Add method to automatically invoice zero-amount orders in sale_loyalty module