### PR TITLE
[REF] fleet: missing hide columns in vehicle list view

### DIFF
--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -1,46 +1,60 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="fleet_vehicle_view_search" model="ir.ui.view">
         <field name="name">fleet.vehicle.search</field>
         <field name="model">fleet.vehicle</field>
         <field name="arch" type="xml">
             <search string="All vehicles">
-                <field name="name" string="Vehicle"
-                    filter_domain="['|', ('name', 'ilike', self), ('license_plate', 'ilike', self)]" />
+                <field
+                    name="name"
+                    string="Vehicle"
+                    filter_domain="['|', ('name', 'ilike', self), ('license_plate', 'ilike', self)]"
+                />
                 <field name="model_id" string="Model" />
                 <field name="license_plate" string="License Plate" />
                 <field name="mobility_card" invisible="1" />
                 <field name="tag_ids" />
                 <field name="vehicle_properties" string="Properties" />
-                <filter name="available" string="Available"
-                    domain="['&amp;', ('future_driver_id', '=', False), ('driver_id', '=', False)]" />
-                <filter name="bikes" string="Bikes"
-                    domain="[('vehicle_type', '=', 'bike')]" />
-                <filter name="cars" string="Cars"
-                    domain="[('vehicle_type', '=', 'car')]" />
-                <filter name="trailer_hook" string="Trailer Hook"
-                    domain="[('trailer_hook', '=', True)]" />
+                <filter
+                    name="available"
+                    string="Available"
+                    domain="['&amp;', ('future_driver_id', '=', False), ('driver_id', '=', False)]"
+                />
+                <filter name="bikes" string="Bikes" domain="[('vehicle_type', '=', 'bike')]" />
+                <filter name="cars" string="Cars" domain="[('vehicle_type', '=', 'car')]" />
+                <filter name="trailer_hook" string="Trailer Hook" domain="[('trailer_hook', '=', True)]" />
                 <separator />
-                <filter name="alert_true" string="Need Action"
-                    domain="['|', ('contract_renewal_due_soon', '=', True), ('contract_renewal_overdue', '=', True)]" />
+                <filter
+                    name="alert_true"
+                    string="Need Action"
+                    domain="['|', ('contract_renewal_due_soon', '=', True), ('contract_renewal_overdue', '=', True)]"
+                />
                 <separator />
-                <filter name="inactive" string="Archived"
-                    domain="[('active', '=', False)]" />
+                <filter name="inactive" string="Archived" domain="[('active', '=', False)]" />
                 <separator />
-                <filter name="activities_overdue" string="Late Activities" invisible="1"
+                <filter
+                    name="activities_overdue"
+                    string="Late Activities"
+                    invisible="1"
                     domain="[('my_activity_date_deadline', '&lt;', context_today().strftime('%Y-%m-%d'))]"
-                    help="Show all records which has next action date is before today" />
-                <filter name="activities_today" string="Today Activities" invisible="1"
-                    domain="[('my_activity_date_deadline', '=', context_today().strftime('%Y-%m-%d'))]" />
-                <filter name="activities_upcoming_all" string="Future Activities" invisible="1"
-                    domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]" />
+                    help="Show all records which has next action date is before today"
+                />
+                <filter
+                    name="activities_today"
+                    string="Today Activities"
+                    invisible="1"
+                    domain="[('my_activity_date_deadline', '=', context_today().strftime('%Y-%m-%d'))]"
+                />
+                <filter
+                    name="activities_upcoming_all"
+                    string="Future Activities"
+                    invisible="1"
+                    domain="[('my_activity_date_deadline', '&gt;', context_today().strftime('%Y-%m-%d'))]"
+                />
                 <group string="Group By" expand="1">
-                    <filter name="groupby_model" string="Model"
-                        context="{'group_by': 'model_id'}" />
-                    <filter name="groupby_make" string="Brand"
-                        context="{'group_by': 'brand_id'}" />
-                    <filter name="groupby_fueltype" string="Fuel Type"
-                        context="{'group_by': 'fuel_type'}" />
+                    <filter name="groupby_model" string="Model" context="{'group_by': 'model_id'}" />
+                    <filter name="groupby_make" string="Brand" context="{'group_by': 'brand_id'}" />
+                    <filter name="groupby_fueltype" string="Fuel Type" context="{'group_by': 'fuel_type'}" />
                 </group>
             </search>
         </field>
@@ -50,36 +64,36 @@
         <field name="name">fleet.vehicle.list</field>
         <field name="model">fleet.vehicle</field>
         <field name="arch" type="xml">
-            <list string="Vehicle"
+            <list
+                string="Vehicle"
                 multi_edit="1"
                 sample="1"
                 decoration-warning="contract_renewal_due_soon and not contract_renewal_overdue"
-                decoration-danger="contract_renewal_overdue">
+                decoration-danger="contract_renewal_overdue"
+            >
                 <field name="active" column_invisible="True" />
                 <field name="license_plate" readonly="1" />
-                <field name="category_id" optional="hide" />
+                <field name="category_id" />
                 <field name="model_id" widget="many2one_avatar" readonly="1" />
                 <field name="driver_id" widget="many2one_avatar_user" readonly="1" optional="show" />
-                <field name="future_driver_id" widget="many2one_avatar_user" readonly="1"
-                    optional="hide" />
+                <field name="future_driver_id" widget="many2one_avatar_user" readonly="1" optional="hide" />
                 <field name="manager_id" widget="many2one_avatar_user" optional="hide" />
                 <field name="odometer" readonly="1" optional="hide" />
                 <field name="vin_sn" readonly="1" optional="hide" />
                 <field name="engine_sn" readonly="1" optional="hide" />
-                <field name="acquisition_date" readonly="1" optional="hide" />
-                <field name="vehicle_properties" />
-                <field name="contract_state" widget="badge"
-                    decoration-info="contract_state == 'open'"
-                    decoration-danger="contract_state == 'expired'"
-                    optional="hide" />
+                <field name="acquisition_date" readonly="1" />
+                <field name="tag_ids" widget="many2many_tags" readonly="1" options="{'color_field': 'color'}" />
                 <field name="contract_renewal_due_soon" column_invisible="1" />
                 <field name="contract_renewal_overdue" column_invisible="1" />
-                <field name="activity_exception_decoration" widget="activity_exception"
-                    optional="hide" />
-                <field name="tag_ids" widget="many2many_tags"
-                    readonly="1"
-                    options="{'color_field': 'color'}"
-                    optional="hide" />
+                <field name="vehicle_properties" />
+                <field
+                    name="contract_state"
+                    widget="badge"
+                    decoration-info="contract_state == 'open'"
+                    decoration-danger="contract_state == 'expired'"
+                    optional="hide"
+                />
+                <field name="activity_exception_decoration" widget="activity_exception" />
             </list>
         </field>
     </record>
@@ -91,13 +105,14 @@
             <kanban sample="1">
                 <field name="contract_renewal_due_soon" />
                 <field name="contract_renewal_overdue" />
-                <progressbar field="activity_state"
-                    colors='{"planned": "success", "today": "warning", "overdue": "danger"}' />
+                <progressbar
+                    field="activity_state"
+                    colors='{"planned": "success", "today": "warning", "overdue": "danger"}'
+                />
                 <templates>
                     <t t-name="card" class="flex-row">
                         <aside class="d-flex align-items-center me-2">
-                            <field name="image_128" widget="image"
-                                options="{'img_class': 'object-fit-cover'}" />
+                            <field name="image_128" widget="image" options="{'img_class': 'object-fit-cover'}" />
                         </aside>
                         <main>
                             <div>
@@ -105,38 +120,50 @@
                                     <field class="fw-bolder fs-5" name="license_plate" />: </t>
                                 <field class="fw-bolder fs-5" name="model_id" />
                             </div>
-                            <field name="tag_ids" widget="many2many_tags"
-                                options="{'color_field': 'color'}" />
-                            <field t-if="record.driver_id.raw_value" name="driver_id"
-                                widget="many2one_avatar" options="{'display_avatar_name': True}"
-                                class="small pt-1 pb-1" />
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" />
+                            <field
+                                t-if="record.driver_id.raw_value"
+                                name="driver_id"
+                                widget="many2one_avatar"
+                                options="{'display_avatar_name': True}"
+                                class="small pt-1 pb-1"
+                            />
                             <div class="small">
                                 <t t-if="record.future_driver_id.raw_value">Future Driver : <field
-                                        name="future_driver_id" /></t>
+                                        name="future_driver_id"
+                                    /></t>
                             </div>
                             <t t-if="record.location.raw_value">
                                 <small>
-                                    <i class="fa fa-map-marker" title="Location"></i>
+                                    <i class="fa fa-map-marker" title="Location" />
                                     <field name="location" />
                                 </small>
                             </t>
                             <field name="vehicle_properties" widget="properties" />
                             <footer class="pt-0 mt-0" t-if="!selection_mode">
                                 <div class="d-flex fs-6">
-                                    <a t-if="record.contract_count.raw_value>0" type="object"
-                                        name="action_view_fleet_vehicle_log" href="#"
-                                        data-context='{"search_default_product_category_id":"fleet.product_category_vehicle_contracts"}'>
+                                    <a
+                                        t-if="record.contract_count.raw_value>0"
+                                        type="object"
+                                        name="action_view_fleet_vehicle_log"
+                                        href="#"
+                                        data-context='{"search_default_product_category_id":"fleet.product_category_vehicle_contracts"}'
+                                    >
                                         <field name="contract_count" /> Contract(s) <span
                                             t-if="record.contract_renewal_due_soon.raw_value and !record.contract_renewal_overdue.raw_value"
                                             class="fa fa-exclamation-triangle text-warning"
-                                            role="img" aria-label="Warning: renewal due soon"
-                                            title="Warning: renewal due soon">
+                                            role="img"
+                                            aria-label="Warning: renewal due soon"
+                                            title="Warning: renewal due soon"
+                                        >
                                         </span>
                                         <span
                                             t-if="record.contract_renewal_overdue.raw_value"
                                             class="fa fa-exclamation-triangle text-danger"
-                                            role="img" aria-label="Attention: renewal overdue"
-                                            title="Attention: renewal overdue">
+                                            role="img"
+                                            aria-label="Attention: renewal overdue"
+                                            title="Attention: renewal overdue"
+                                        >
                                         </span>
                                     </a>
                                     <field name="activity_ids" widget="kanban_activity" class="ms-2" />
@@ -167,9 +194,13 @@
             <form string="Vehicle" js_class="fleet_form">
                 <field name="service_activity" invisible="1" />
                 <header>
-                    <button name="accept_driver_change" string="Apply New Driver"
-                        type="object" class="btn btn-primary"
-                        invisible="not future_driver_id" />
+                    <button
+                        name="accept_driver_change"
+                        string="Apply New Driver"
+                        type="object"
+                        class="btn btn-primary"
+                        invisible="not future_driver_id"
+                    />
                 </header>
                 <sheet>
                     <field name="company_id" invisible="1" />
@@ -178,41 +209,55 @@
                     <field name="active" invisible="1" />
                     <field name="vehicle_type" invisible="1" />
                     <div name="button_box" class="oe_button_box">
-                        <button name="action_view_assignation_logs"
-                            type="object" class="oe_stat_button"
-                            icon="fa-history">
+                        <button
+                            name="action_view_assignation_logs"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-history"
+                        >
                             <field name="assignment_count" string="Drivers" widget="statinfo" />
                         </button>
-                        <button name="action_view_contract_logs"
-                            type="object" class="oe_stat_button"
+                        <button
+                            name="action_view_contract_logs"
+                            type="object"
+                            class="oe_stat_button"
                             icon="fa-book"
-                            help="show the contract for this vehicle">
+                            help="show the contract for this vehicle"
+                        >
                             <field name="contract_count" string="Contracts" widget="statinfo" />
                         </button>
-                        <button name="action_view_service_logs"
-                            type="object" class="oe_stat_button"
+                        <button
+                            name="action_view_service_logs"
+                            type="object"
+                            class="oe_stat_button"
                             icon="fa-wrench"
                             invisible="service_activity != 'none'"
-                            help="show the services logs for this vehicle">
+                            help="show the services logs for this vehicle"
+                        >
                             <field name="service_count" string="Services" widget="statinfo" />
                         </button>
-                        <button name="action_view_service_logs"
-                            type="object" class="oe_stat_button text-danger"
+                        <button
+                            name="action_view_service_logs"
+                            type="object"
+                            class="oe_stat_button text-danger"
                             icon="fa-wrench"
                             invisible="service_activity != 'overdue'"
-                            help="show the services logs for this vehicle">
+                            help="show the services logs for this vehicle"
+                        >
                             <field name="service_count" string="Services" widget="statinfo" />
                         </button>
-                        <button name="action_view_service_logs"
-                            type="object" class="oe_stat_button text-warning"
+                        <button
+                            name="action_view_service_logs"
+                            type="object"
+                            class="oe_stat_button text-warning"
                             icon="fa-wrench"
                             invisible="service_activity != 'today'"
-                            help="show the services logs for this vehicle">
+                            help="show the services logs for this vehicle"
+                        >
                             <field name="service_count" string="Services" widget="statinfo" />
                         </button>
                     </div>
-                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger"
-                        invisible="active" />
+                    <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active" />
                     <field name="image_128" widget='image' class="oe_avatar" />
                     <div name="title" class="oe_title">
                         <label for="name" />
@@ -228,18 +273,25 @@
                             <field name="license_plate" class="oe_inline" placeholder="e.g. PAE 326" />
                         </h2>
                         <label for="tag_ids" />
-                        <field name="tag_ids" widget="many2many_tags"
-                            options="{'color_field': 'color', 'no_create_edit': True}" />
+                        <field
+                            name="tag_ids"
+                            widget="many2many_tags"
+                            options="{'color_field': 'color', 'no_create_edit': True}"
+                        />
                     </div>
                     <group col="2">
                         <group string="Driver">
-                            <field name="driver_id"
+                            <field
+                                name="driver_id"
                                 widget="many2one_avatar"
-                                domain="['|', ('company_id', '=', False ), ('company_id', '=', company_id)]" />
+                                domain="['|', ('company_id', '=', False ), ('company_id', '=', company_id)]"
+                            />
                             <field name="future_driver_id" widget="many2one_avatar" />
-                            <field name="manager_id"
+                            <field
+                                name="manager_id"
                                 widget="many2one_avatar_user"
-                                domain="[('share', '=', False), ('company_id', '=', company_id)]" />
+                                domain="[('share', '=', False), ('company_id', '=', company_id)]"
+                            />
                             <field name="acquisition_date" invisible="vehicle_type != 'car'" />
                             <field name="write_off_date" invisible="vehicle_type != 'car'" />
                             <field name="next_assignation_date" />
@@ -253,8 +305,7 @@
                             <div invisible="vehicle_type != 'car'">
                                 <field name="odometer" class="oe_inline" />
                                 <span> in </span>
-                                <field name="odometer_uom_id" class="oe_inline"
-                                    options="{'no_create': True}" />
+                                <field name="odometer_uom_id" class="oe_inline" options="{'no_create': True}" />
                             </div>
                         </group>
                     </group>
@@ -265,30 +316,22 @@
                                 <group name="group_model" string="Model">
                                     <field name="vin_sn" />
                                     <field name="model_year" />
-                                    <field name="transmission"
-                                        invisible="vehicle_type != 'car'" />
+                                    <field name="transmission" invisible="vehicle_type != 'car'" />
                                     <field name="color" />
-                                    <field name="seats"
-                                        invisible="vehicle_type != 'car'" />
-                                    <field name="doors"
-                                        invisible="vehicle_type != 'car'" />
-                                    <field name="trailer_hook"
-                                        invisible="vehicle_type != 'car'" />
-                                    <field name="electric_assistance"
-                                        invisible="vehicle_type != 'bike'" />
+                                    <field name="seats" invisible="vehicle_type != 'car'" />
+                                    <field name="doors" invisible="vehicle_type != 'car'" />
+                                    <field name="trailer_hook" invisible="vehicle_type != 'car'" />
+                                    <field name="electric_assistance" invisible="vehicle_type != 'bike'" />
                                 </group>
                                 <group string="Engine" invisible="vehicle_type != 'car'">
                                     <field name="engine_sn" />
                                     <field name="power_unit" />
-                                    <label for="power"
-                                        invisible="power_unit != 'power'" />
-                                    <div class="o_row"
-                                        invisible="power_unit != 'power'">
+                                    <label for="power" invisible="power_unit != 'power'" />
+                                    <div class="o_row" invisible="power_unit != 'power'">
                                         <field name="power" />
                                         <span>kW</span>
                                     </div>
-                                    <field name="horsepower"
-                                        invisible="power_unit != 'horsepower'" />
+                                    <field name="horsepower" invisible="power_unit != 'horsepower'" />
                                     <label for="vehicle_range" />
                                     <div class="o_row">
                                         <field name="vehicle_range" />
@@ -297,14 +340,12 @@
                                     <field name="fuel_type" />
                                     <label for="fuel_tank_capacity" />
                                     <div class="o_row">
-                                        <field name="fuel_tank_capacity" />
-                                        <span>L</span>
+                                        <field name="fuel_tank_capacity" /><span>L</span>
                                     </div>
                                     <field name="cilinders" />
                                     <label for="fuel_efficiency" />
                                     <div class="o_row">
-                                        <field name="fuel_efficiency" />
-                                        <span>km/L</span>
+                                        <field name="fuel_efficiency" /><span>km/L</span>
                                     </div>
                                     <label for="co2" />
                                     <div class="o_row" name="co2">
@@ -335,8 +376,11 @@
                             </group>
                         </page>
                         <page name="note" string="Note">
-                            <field name="description" nolabel="1"
-                                placeholder="Write here any other information related to this vehicle" />
+                            <field
+                                name="description"
+                                nolabel="1"
+                                placeholder="Write here any other information related to this vehicle"
+                            />
                         </page>
                     </notebook>
                 </sheet>
@@ -354,9 +398,13 @@
                 <field name="id" />
                 <templates>
                     <div t-name="activity-box">
-                        <img class="rounded-circle"
+                        <img
+                            class="rounded-circle"
                             t-att-src="activity_image('fleet.vehicle', 'image_128', record.id.raw_value)"
-                            role="img" t-att-title="record.id.value" t-att-alt="record.id.value" />
+                            role="img"
+                            t-att-title="record.id.value"
+                            t-att-alt="record.id.value"
+                        />
                         <div class="ms-2">
                             <field name="license_plate" display="full" class="o_text_block" />
                             <field name="model_id" muted="1" class="o_text_block" />

--- a/addons/purchase_stock/models/stock_picking.py
+++ b/addons/purchase_stock/models/stock_picking.py
@@ -11,7 +11,7 @@ class StockPicking(models.Model):
     # ------------------------------------------------------------
 
     purchase_id = fields.Many2one(
-        related="move_ids.purchase_line_id.order_id",
+        comodel_name="purchase.order",
         string="Purchase Orders",
         readonly=True,
     )


### PR DESCRIPTION
# [Task #7784](https://agromarin.mx/odoo/project/22/tasks/7784)

## Summary by Sourcery

Enable hideable columns in fleet vehicle and vehicle log views by migrating invisible attributes to column_invisible and optional hide flags, and standardize XML formatting for consistency.

Bug Fixes:
- Restore hideable columns in the vehicle list view for mobility card, contract renewal fields, and contract state badge.
- Apply context-driven column hiding in the vehicle log list view for driver, product category, product, and vendor fields.

Enhancements:
- Replace invisible attributes with column_invisible and optional="hide" across fleet vehicle and log views to leverage Odoo’s column hiding feature.
- Clean up XML formatting by splitting attributes onto separate lines and normalizing indentation across multiple view files.

### Extra

**Included this fix:**

![WhatsApp Image 2025-05-28 at 10 09 40 AM](https://github.com/user-attachments/assets/d7089ccc-fd09-42b9-8573-f9badf3900cd)
