### PR TITLE
[FIX] purchase_stock: missing purchase_id while preparing picking values

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -542,6 +542,7 @@ class PurchaseOrder(models.Model):
             )
 
         return {
+            "purchase_id": self.id,
             "picking_type_id": self.picking_type_id.id,
             "partner_id": self.partner_id.id,
             "user_id": False,


### PR DESCRIPTION
# [Task #7870](https://agromarin.mx/odoo/project/22/tasks/7870)

![OC-25-05-0151-05-29-2025_10_07_AM](https://github.com/user-attachments/assets/c60fe257-dca8-4df3-b4d0-ef0138c1097d)

## Summary by Sourcery

Bug Fixes:
- Ensure purchase_id is included in prepared picking values to correctly link pickings to their purchase order