### PR TITLE
[FIX] purchase: allow purchase matching from a posted invoice

### DIFF
--- a/addons/purchase/wizard/purchase_bill_line_match.py
+++ b/addons/purchase/wizard/purchase_bill_line_match.py
@@ -168,7 +168,6 @@ class PurchaseBillLineMatch(models.Model):
         residual_purchase_order_lines = self.pol_id
         residual_account_move_lines = self.aml_id
         residual_bill = self.aml_id.move_id
-
         # Match all matchable POL-AML lines and remove them from the residual group
         for product, po_line in pol_by_product.items():
             po_line = po_line[
@@ -185,7 +184,8 @@ class PurchaseBillLineMatch(models.Model):
             residual_account_move_lines.unlink()
 
         # Add all remaining POL to the residual bill
-        residual_bill._add_purchase_order_lines(residual_purchase_order_lines)
+        if residual_purchase_order_lines:
+            residual_bill._add_purchase_order_lines(residual_purchase_order_lines)
 
     def action_add_to_po(self):
         if not self or not self.aml_id:


### PR DESCRIPTION
It was making an unnecessary writing over invoice_line_ids field

**Description of the issue/feature this PR addresses:**

1. Entrar a Contabilidad -> Proveedores -> Factura
2. Seleccionar PF/25/05/0719
3. Ir a Purchase Matching
4. Seleccionar PF/25/05/0719 y OC/25/05/0131
5. Hacer click en Conciliar

**Current behavior before PR:**
- No completa la conciliación debido a un error

**Desired behavior after PR is merged:**
- Se debe permitir la conciliación

**Screenshoot**

![WhatsApp Image 2025-05-31 at 9 10 16 AM](https://github.com/user-attachments/assets/10ac52fe-61c4-4451-9924-a5b59f9acb38)

![WhatsApp Image 2025-05-31 at 9 10 17 AM](https://github.com/user-attachments/assets/380c4760-d3d9-45ff-8199-4033fc1a6d69)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

## Summary by Sourcery

Bug Fixes:
- Add a conditional to skip calling `_add_purchase_order_lines` when no residual purchase order lines remain, preventing an unnecessary write on `invoice_line_ids` and fixing reconciliation errors on posted invoices.