### PR TITLE
[FIX] Added move_line_ids validation in picking_report

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -139,7 +139,7 @@
                                             </td>
                                             <!-- If a move contains only one move line, the move is summarized in the heading only -->
                                             <td class="text-start" t-if="from_col_exists" groups="stock.group_stock_multi_locations">
-                                                <div t-if="not move_has_multiple_lines">
+                                                <div t-if="move.move_line_ids and not move_has_multiple_lines">
                                                     <span t-field="move.move_line_ids[0].location_id.display_name">WH/Stock</span>
                                                     <t t-if="move.move_line_ids and move.move_line_ids[0].package_id">
                                                         <span t-field="move.move_line_ids[0].package_id">Package A</span>
@@ -148,7 +148,7 @@
                                             </td>
                                             <!-- If a move contains only one move line, the move is summarized in the heading only -->
                                             <td class="text-start" t-if="to_col_exists" groups="stock.group_stock_multi_locations">
-                                                <div t-if="not move_has_multiple_lines">
+                                                <div t-if="move.move_line_ids and not move_has_multiple_lines">
                                                     <span t-field="move.move_line_ids[0].location_dest_id.display_name">WH/Outgoing</span>
                                                     <t t-if="move.move_line_ids and move.move_line_ids[0].result_package_id">
                                                         <span t-field="move.move_line_ids[0].result_package_id">Package B</span>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

## Summary by Sourcery

Bug Fixes:
- Include checks for move.move_line_ids before accessing the first line in both 'from' and 'to' location cells of the picking report