### PR TITLE
[FIX] sale: missing renaming amount fields for sale order line model

### DIFF
--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -110,14 +110,14 @@ class ResPartner(models.Model):
                         ("commercial_partner_id", "in", self.commercial_partner_id.ids),
                     ],
                 ),
-                ("line_ids", "any", [("untaxed_amount_to_invoice", ">", 0)]),
+                ("line_ids", "any", [("amount_to_invoice_taxexc", ">", 0)]),
                 ("state", "=", "sale"),
             ]
         )
         for (partner, currency), orders in sale_orders.grouped(
             lambda so: (so.partner_invoice_id, so.currency_id),
         ).items():
-            amount_to_invoice_sum = sum(orders.mapped("amount_to_invoice"))
+            amount_to_invoice_sum = sum(orders.mapped("amount_to_invoice_taxinc"))
             credit_company_currency = currency._convert(
                 amount_to_invoice_sum,
                 company.currency_id,

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -110,7 +110,7 @@ class ResPartner(models.Model):
                         ("commercial_partner_id", "in", self.commercial_partner_id.ids),
                     ],
                 ),
-                ("order_line", "any", [("untaxed_amount_to_invoice", ">", 0)]),
+                ("line_ids", "any", [("untaxed_amount_to_invoice", ">", 0)]),
                 ("state", "=", "sale"),
             ]
         )


### PR DESCRIPTION
## Summary by Sourcery

Fix partner credit-to-invoice computation by using the renamed amount fields on sale orders and order lines

Bug Fixes:
- Replace deprecated order_line/untaxed_amount_to_invoice filter with line_ids/amount_to_invoice_taxexc
- Summate amount_to_invoice_taxinc instead of the old amount_to_invoice when calculating order credit