### PR TITLE
[FIX] project: re-apply 'todo' state support in task state widget

### DIFF
--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
@@ -24,14 +24,16 @@ export class ProjectTaskStateSelection extends StateSelectionField {
             isStateButtonHighlighted: false,
         });
         this.icons = {
+            "todo": "o_status o_status_todo",
             "in_progress": "o_status",
             "approved": "o_status o_status_green",
-            "changes_requested": "fa-solid fa-exclamation-circle fa-lg",
-            "done": "fa-solid fa-check-circle fa-lg",
-            "canceled": "fa-solid fa-times-circle fa-lg",
+            "changes_requested": "fa-solid fa-circle-exclamation fa-lg",
+            "done": "fa-solid fa-circle-check fa-lg",
+            "canceled": "fa-solid fa-circle-xmark fa-lg",
             "blocked": "fa-solid fa-hourglass fa-lg",
         };
         this.colorIcons = {
+            "todo": "",
             "in_progress": "",
             "approved": "text-success",
             "changes_requested": "o_status_changes_requested",
@@ -40,6 +42,7 @@ export class ProjectTaskStateSelection extends StateSelectionField {
             "blocked": "btn-outline-info",
         };
         this.colorButton = {
+            "todo": "btn-outline-info",
             "in_progress": "btn-outline-secondary",
             "approved": "btn-outline-success",
             "changes_requested": "btn-outline-warning",
@@ -83,7 +86,7 @@ export class ProjectTaskStateSelection extends StateSelectionField {
         const states = ["canceled", "done"];
         const currentState = this.props.record.data[this.props.name];
         if (currentState != "blocked") {
-            states.unshift("in_progress", "changes_requested", "approved");
+            states.unshift("todo", "in_progress", "changes_requested", "approved");
         }
         return states.map((state) => [state, labels.get(state)]);
     }

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.scss
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.scss
@@ -6,22 +6,17 @@
         margin-top: -0.5px;
     }
 
-    .fa-lg {
+    .fa-solid {
         font-size: 1.75em;
         margin-top: -2.5px;
         max-width: 20px;
         max-height: 20px;
     }
 
-    .fa-hourglass-o {
-        font-size: 1.4em !important;
-        margin-top: 0.5px !important;
-    }
-
     .o_task_state_list_view {
         height: $o-line-size;
 
-        .fa-lg {
+        .fa-solid {
             font-size: 1.315em;
             vertical-align: -6%;
         }
@@ -29,39 +24,47 @@
             width: $o-bubble-color-size;
             height: $o-bubble-color-size;
         }
-        .fa-hourglass-o {
-            font-size: 1.15em !important;
-            padding-left: 1px !important;
-        }
     }
 
     .o_status_changes_requested {
         color: $warning;
     }
+
+    .o_status_todo {
+        background-color: map-get($theme-colors, "info");
+    }
 }
 
 .project_task_state_selection_menu {
-    .fa {
-        margin-top: -1.5px;
+    $dropdown-icon-size: 14.65px;
+
+    .fa-solid {
         font-size: 1.315em;
-        vertical-align: -6%;
+        display: inline-block;
+        width: $dropdown-icon-size;
+        text-align: center;
+        vertical-align: middle;
         transform: translateX(-50%);
     }
 
     .o_status {
         margin-top: 1px;
-        width: 14.65px;
-        height: 14.65px;
+        width: $dropdown-icon-size;
+        height: $dropdown-icon-size;
         text-align: center;
     }
 
     .o_status_changes_requested {
         color: $warning;
     }
+
+    .o_status_todo {
+        background-color: map-get($theme-colors, "info");
+    }
 }
 
 .o_field_task_step_with_state_selection {
-    .fa-lg {
+    .fa-solid {
         font-size: 1.57em;
     }
 }

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
@@ -20,7 +20,7 @@
         </xpath>
         <!-- The toggle mark as done button -->
         <xpath expr="//t[@t-if='props.readonly']" position="after">
-            <t t-elif="isToggleMode and currentValue == 'in_progress'">
+            <t t-elif="isToggleMode and ['todo', 'in_progress'].includes(currentValue)">
                 <button t-if="isView(['activity', 'kanban', 'list', 'calendar']) or this.env.isSmall"
                         class="d-flex align-items-center btn fw-normal p-0"
                         tabindex="-1"
@@ -42,8 +42,8 @@
                                     Mark as done
                                 </span>
                             </t>
-                            <t t-else="currentValue == 'in_progress'">
-                                In Progress
+                            <t t-else="">
+                                <t t-out="label"/>
                             </t>
                         </span>
                     </div>

--- a/addons/project/static/tests/project_task_state_selection.test.js
+++ b/addons/project/static/tests/project_task_state_selection.test.js
@@ -35,12 +35,12 @@ test("project.task (kanban): check task state widget", async () => {
 
     await click(".o-dropdown--menu span.text-danger");
     await animationFrame();
-    expect("div[name='state']:first-child button.dropdown-toggle i.fa-times-circle").toBeVisible({
+    expect("div[name='state']:first-child button.dropdown-toggle i.fa-circle-xmark").toBeVisible({
         message:
-            "If the canceled state as been selected, the fa-times-circle icon should be displayed",
+            "If the canceled state as been selected, the fa-circle-xmark icon should be displayed",
     });
 
-    await click("div[name='state'] i.fa-hourglass-o");
+    await click("div[name='state'] i.fa-hourglass");
     await animationFrame();
     expect(".o-dropdown--menu").toHaveCount(0, {
         message: "When trying to click on the waiting icon, no dropdown menu should display",
@@ -63,6 +63,7 @@ test("project.task (form): check task state widget", async () => {
     await click("button.o_state_button");
     await animationFrame();
     expect(queryAllTexts(".state_selection_field_menu > .dropdown-item")).toEqual([
+        "To Do",
         "In Progress",
         "Changes Requested",
         "Approved",


### PR DESCRIPTION
Commits 9ad93e7135bb and 8b1769db02a5 (code quality refactor and ESM native migration) inadvertently reverted the changes from PR #81 that added 'todo' state support to the project_task_state_selection widget.

Re-apply all changes from the original fix:
- Add 'todo' to icons/colorIcons/colorButton mappings in JS
- Include 'todo' in dropdown options (get options())
- Enable toggle mode from 'todo' state in XML template
- Use dynamic label in toggle button (shows "To Do" or "In Progress")
- Add .o_status_todo SCSS class with info background color
- Migrate FA5 icon names to FA7: fa-circle-exclamation, fa-circle-check, fa-circle-xmark
- Migrate SCSS selectors from .fa/.fa-lg to .fa-solid (FA7 standard)
- Remove legacy .fa-hourglass-o SCSS rules
- Update test selectors to match FA7 icon class names

Task ID: 19628
