### PR TITLE
[FIX] tools: re-export _contains_dot_segments in urls.py

### DIFF
--- a/odoo/tools/urls.py
+++ b/odoo/tools/urls.py
@@ -7,6 +7,7 @@ from odoo.http import request
 
 # Re-export from canonical location
 from odoo.libs.web.urls import *  # noqa: F403
+from odoo.libs.web.urls import _contains_dot_segments  # noqa: F401 — used by website.models.website
 
 
 def keep_query(*keep_params: str, **additional_params: object) -> str:


### PR DESCRIPTION
# [Task ID: 20541](https://agromarin.mx/odoo/project.task/20541)

Re-export `_contains_dot_segments` in `odoo/tools/urls.py` to fix AttributeError when setting website domains.

---

## Problem

The fork created `odoo/tools/urls.py` which shadows the canonical module `odoo.libs.web.urls`. This file uses `from odoo.libs.web.urls import *` but `__all__` in the original module only exports `urljoin`, excluding underscore-prefixed functions like `_contains_dot_segments`.

When `website.models.website` (line 424) tries to access `tools.urls._contains_dot_segments` to validate website domain URLs, it raises:

```
AttributeError: module 'odoo.tools.urls' has no attribute '_contains_dot_segments'
```

---

## Solution

### odoo/tools/urls.py
- Add explicit re-import: `from odoo.libs.web.urls import _contains_dot_segments`

---

## Verification

- [ ] Create or edit a website record with a domain URL → no AttributeError
- [ ] `odoo-bin shell` → `from odoo.tools.urls import _contains_dot_segments` works