### PR TITLE
[FIX] base: resolve esbuild library aliases dynamically across addon …

### DIFF
--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -554,16 +554,20 @@ class AssetsBundle:
         # instead of externalizing (--external:@odoo/* would leave them
         # as bare imports that the browser can't resolve).
         # Aliases are resolved BEFORE externals, so these override --external.
-        odoo_lib_aliases = {
-            "@odoo/hoot-dom": (Path(_addon_paths[2]) / "web" / "static" / "lib" / "hoot-dom" / "hoot-dom.js"),
-            "@popperjs/core": (Path(_addon_paths[2]) / "web" / "static" / "lib" / "popper" / "popper.esm.js"),
+        # Library paths are resolved dynamically across all addon paths
+        # because the index order depends on addons_path configuration.
+        _lib_candidates = {
+            "@odoo/hoot-dom": ("web", "static", "lib", "hoot-dom", "hoot-dom.js"),
+            "@popperjs/core": ("web", "static", "lib", "popper", "popper.esm.js"),
+            "@odoo/o-spreadsheet": ("spreadsheet", "static", "src", "o_spreadsheet", "o_spreadsheet.js"),
         }
-        # @odoo/o-spreadsheet: alias from o_spreadsheet.js header
-        for addon_dir in _addon_paths:
-            o_spreadsheet = Path(addon_dir) / "spreadsheet" / "static" / "src" / "o_spreadsheet" / "o_spreadsheet.js"
-            if o_spreadsheet.exists():
-                odoo_lib_aliases["@odoo/o-spreadsheet"] = o_spreadsheet
-                break
+        odoo_lib_aliases = {}
+        for alias_name, path_parts in _lib_candidates.items():
+            for addon_dir in _addon_paths:
+                candidate = Path(addon_dir).joinpath(*path_parts)
+                if candidate.exists():
+                    odoo_lib_aliases[alias_name] = candidate
+                    break
         for name, lib_path in odoo_lib_aliases.items():
             if lib_path.exists():
                 rel = os.path.relpath(lib_path, odoo_root)


### PR DESCRIPTION
…paths

The ESM bundling pipeline hardcoded _addon_paths[2] to locate library files (hoot-dom, popper.esm.js), assuming the third addon path was always core/addons. This assumption breaks when addons_path in the config has a different ordering (e.g., design-themes at index 2), causing esbuild to fail with "Could not resolve @popperjs/core".

Resolve all library aliases dynamically by iterating addon paths until the file is found, matching the pattern already used for o-spreadsheet. Consolidate all three library lookups into a single loop.

Task ID: 20116

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
