### PR TITLE
[FIX] web, project: unblock esbuild bundling (formatXML, luxon)

### DIFF
--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_controller.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_controller.js
@@ -1,7 +1,6 @@
 /** @odoo-module native */
 import { useRef } from "@odoo/owl";
 
-import * as luxon from "luxon";
 import { _t } from "@web/core/l10n/translation";
 import { CalendarController } from "@web/views/calendar/calendar_controller";
 import { subTaskDeleteConfirmationMessage } from "@project/views/project_task_form/project_task_form_controller";
@@ -82,7 +81,7 @@ export class ProjectTaskCalendarController extends CalendarController {
         if (timeSlotElement) {
             dateStr += `T${timeSlotElement.dataset.time}`;
         }
-        const date = luxon.DateTime.fromISO(dateStr);
+        const date = globalThis.luxon.DateTime.fromISO(dateStr);
         if (date.isValid) {
             element.hidden = true;
             await this.model.planTask(taskId, date, Boolean(timeSlotElement));

--- a/addons/web/static/src/core/utils/dom/xml.js
+++ b/addons/web/static/src/core/utils/dom/xml.js
@@ -167,3 +167,93 @@ export function setAttributes(node, attributes) {
         node.setAttribute(name, value);
     }
 }
+
+/**
+ * Pretty-print an XML string with proper indentation.
+ *
+ * Regex-based formatter that handles elements, comments, CDATA,
+ * DOCTYPE, processing instructions, and xmlns attributes.
+ *
+ * @param {string} xml raw XML string
+ * @param {number} [indent=4] spaces per indentation level
+ * @returns {string} formatted XML
+ */
+export function formatXML(xml, indent = 4) {
+    const pad = " ".repeat(indent);
+    // Collapse inter-tag whitespace, then split so each tag becomes a
+    // separate token while preserving text content between tags.
+    const tokens = xml
+        .replace(/>\s+</g, "><")
+        .replace(/</g, "~::~<")
+        .replace(/\s*xmlns:/g, "~::~xmlns:")
+        .replace(/\s*xmlns=/g, "~::~xmlns=")
+        .split("~::~")
+        .filter(Boolean);
+
+    let depth = 0;
+    let inComment = false;
+    const lines = [];
+
+    for (let ix = 0; ix < tokens.length; ix++) {
+        const token = tokens[ix];
+
+        // Comment / CDATA / DOCTYPE start
+        if (/^<!/.test(token)) {
+            lines.push(pad.repeat(depth) + token);
+            inComment = true;
+            if (/-->|]>|!DOCTYPE/.test(token)) {
+                inComment = false;
+            }
+            continue;
+        }
+        // Comment / CDATA end
+        if (/-->|]>/.test(token)) {
+            lines.push(token);
+            inComment = false;
+            continue;
+        }
+        if (inComment) {
+            lines.push(token);
+            continue;
+        }
+        // Closing tag that directly follows its matching opening tag
+        // (e.g. <field name="x">Text</field> → keep on one line).
+        if (/^<\//.test(token)) {
+            const prev = ix > 0 ? tokens[ix - 1] : "";
+            const openTag = /^<([\w:.,-]+)/.exec(prev);
+            const closeTag = /^<\/([\w:.,-]+)/.exec(token);
+            if (openTag && closeTag && openTag[1] === closeTag[1]) {
+                // Append to previous line instead of adding a new one.
+                lines[lines.length - 1] += token;
+                if (!inComment) {
+                    depth--;
+                }
+            } else {
+                lines.push(pad.repeat(--depth) + token);
+            }
+        }
+        // Self-closing tag (check anywhere in token, not just end —
+        // the token may be "<tag/>text" when text follows a self-closer).
+        else if (/^<\w/.test(token) && /\/>/.test(token) && !/<\//.test(token)) {
+            lines.push(pad.repeat(depth) + token);
+        }
+        // Processing instruction <?...?>
+        else if (/^<\?/.test(token)) {
+            lines.push(pad.repeat(depth) + token);
+        }
+        // Opening tag (no self-close or closing tag anywhere in token)
+        else if (/^<\w/.test(token) && !/<\//.test(token) && !/\/>/.test(token)) {
+            lines.push(pad.repeat(depth++) + token);
+        }
+        // Opening + closing on same token: <el>text</el>
+        else if (/^<\w/.test(token)) {
+            lines.push(pad.repeat(depth) + token);
+        }
+        // xmlns continuation or bare text content
+        else {
+            lines.push(pad.repeat(depth) + token);
+        }
+    }
+
+    return lines.join("\n");
+}


### PR DESCRIPTION
# [Task ID: 20729](https://agromarin.mx/odoo/project.task/20729)

Unblock esbuild bundling in `19.0-marin` by restoring the missing `formatXML` export and fixing an orphan luxon import.

---

## Problem

On `19.0-marin`, esbuild failed with `exit 1` on every request to `/odoo`, forcing Odoo to fall back to individual JS files and slow down every page load. The original error in `assetsbundle.py:634` was truncated to 500 chars, which hid two fatal `✘ [ERROR]` messages behind three cosmetic warnings.

After raising the stderr cap temporarily to 5000 chars, the real errors surfaced:

1. **`No matching export in "addons/web/static/src/core/utils/dom/xml.js" for import "formatXML"`** — triggered by `addons/website/.../resource_editor/utils.js:3` and `resource_editor.js:16`. The `formatXML` function was implemented in commit `5dc7f9fb86fa` on branch `agromarin/19.0-imp-mail-ruff-styling`, but that commit never reached `19.0-marin`. The imports did land here, leaving the resource editor broken both under the bundler and at runtime.
2. **`Could not resolve "luxon"`** — triggered by `addons/project/static/src/views/project_task_calendar/project_task_calendar_controller.js:4` which contained `import * as luxon from "luxon"`. `luxon` is not listed in esbuild's `--external` flags (only `@odoo/*` is) nor in `_ODOO_EXTERNAL_LIBS`. The rest of the codebase uses `globalThis.luxon.DateTime` (luxon is loaded as a UMD global in this fork). This was the only file in the codebase with that import pattern — an orphan from a partial cherry-pick.

---

## Solution

### addons/web/static/src/core/utils/dom/xml.js
- Add the missing \`formatXML\` function (88 lines, pretty-prints XML with indentation). Ported verbatim from commit \`5dc7f9fb86fa\`. Additive — no existing exports changed.

### addons/project/static/src/views/project_task_calendar/project_task_calendar_controller.js
- Remove \`import * as luxon from "luxon"\`.
- Replace \`luxon.DateTime.fromISO(dateStr)\` with \`globalThis.luxon.DateTime.fromISO(dateStr)\` to align with the canonical pattern used everywhere else in the codebase.

---

## Verification

- [x] Restart Odoo and load \`/odoo\` — \`esbuild bundling failed\` no longer appears in server logs.
- [x] Browser console clean of \`luxon\` / \`formatXML\` errors.
- [x] Drag & drop a task in the Project Calendar view (luxon path).
- [x] Open the HTML / CSS / JS editor in Website and format XML (formatXML path).