### PR TITLE
[FIX] web: theme-aware statusbar blur

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -305,7 +305,7 @@
         margin-inline: calc(-1 * var(--formView-sheetBg-padding-x)) calc(-1 * var(--formView-sheetBg-padding-right, var(--formView-sheetBg-padding-x)));
         padding-inline: var(--formView-sheetBg-padding-x) var(--formView-sheetBg-padding-right, var(--formView-sheetBg-padding-x));
         border-radius: 0;
-        background-color: rgba(#1C2639, 0.8);
+        background-color: rgba($o-view-background-color, 0.8);
         backdrop-filter: blur(10px);
 
         @include media-breakpoint-up(md) {


### PR DESCRIPTION
# [Task ID: 20756](https://agromarin.mx/odoo/project.task/20756)

Fix statusbar blur background to adapt to light/dark theme automatically.

---

## Problem

The form view statusbar uses a hardcoded dark background color
(`rgba(#1C2639, 0.8)`) with `backdrop-filter: blur(10px)`. This produces
a dark glass effect that looks correct in dark theme but is jarring and
out of place on the light theme.

---

## Solution

### addons/web/static/src/views/form/form_controller.scss
- Replace hardcoded `rgba(#1C2639, 0.8)` with `rgba($o-view-background-color, 0.8)`
- Light theme renders `rgba(white, 0.8)` — white translucent glass blur
- Dark theme renders `rgba(#151D2E, 0.8)` — dark glass blur (nearly identical to previous value)

---

## Verification

- [ ] Open any form view with statusbar in **light theme** — blur should be white/translucent
- [ ] Open any form view with statusbar in **dark theme** — blur should remain dark
- [ ] Verify sticky behavior on scroll still works correctly