### PR TITLE
[FIX] base, service: PgBouncer protocol downgrade and cron idle timeout

### DIFF
--- a/odoo/db/utils.py
+++ b/odoo/db/utils.py
@@ -68,7 +68,9 @@ _HEALTH_PARAMS: dict[str, str] = {
     "keepalives_count": "3",  # give up after 3 failures
     # PG18 wire protocol 3.2: 256-bit cancel keys (vs 32-bit in 3.0).
     # First protocol change since PG 7.4 (2003).
-    "min_protocol_version": "3.2",
+    # Lowered to 3.0 so psycopg accepts the downgrade when PgBouncer
+    # (which only speaks 3.0) sits between Odoo and PG18.
+    "min_protocol_version": "3.0",
 }
 
 

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1547,6 +1547,10 @@ class WorkerCron(Worker):
         self.dbcursor.execute("SELECT pg_is_in_recovery()")
         in_recovery = self.dbcursor.fetchone()[0]
         if not in_recovery:
+            # Disable idle_session_timeout for this connection: it stays idle
+            # by design (waiting for NOTIFY) and must not be killed by PG18's
+            # default timeout.
+            self.dbcursor.execute("SET idle_session_timeout = 0")
             self.dbcursor.execute("LISTEN cron_trigger")
         else:
             self.logger.warning("PG cluster in recovery mode, cron trigger not activated")


### PR DESCRIPTION
# [Task ID: 20764](https://agromarin.mx/odoo/project.task/20764)

## Problem

Two issues from the PgBouncer 1.25 + PG18 production deployment:

1. **Protocol mismatch**: PgBouncer only speaks wire protocol 3.0, but `min_protocol_version` was set to 3.2 (PG18 default). psycopg rejects the downgraded connection from the pooler.
2. **Cron listener killed**: `WorkerCron` opens a persistent LISTEN connection that is idle by design. PG18's `idle_session_timeout` (~15 min) kills the socket, breaking cron trigger delivery.

## Solution

- `odoo/db/utils.py`: lower `min_protocol_version` from `3.2` to `3.0` — psycopg accepts the protocol downgrade via PgBouncer; no-op when connecting directly to PG18.
- `odoo/service/server.py`: `SET idle_session_timeout = 0` in `WorkerCron._connect_postgres` before `LISTEN cron_trigger` — keeps the cron connection alive without relaxing the global timeout.

## Verification

- Both fixes have been running in production since 2026-03-05 without issues.
- Local dev (foreground, no workers): `min_protocol_version` 3.0 is accepted by PG18 direct connection; WorkerCron code path is not executed in threaded mode.