### PR TITLE
[FIX] purchase, web: production uncommitted fixes

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1036,7 +1036,7 @@ class PurchaseOrder(models.Model):
         # Cancel related draft invoices (if any)
         draft_invoices = self.invoice_ids.filtered(lambda inv: inv.state == "draft")
         if draft_invoices:
-            draft_invoices.button_cancel()
+            draft_invoices.action_cancel()
 
         # Update state to cancelled
         self.write({"state": "cancel"})

--- a/addons/web/static/src/components/datetime/datetime_picker.js
+++ b/addons/web/static/src/components/datetime/datetime_picker.js
@@ -8,8 +8,8 @@ import { TimePicker } from "@web/components/time_picker/time_picker";
 import {
     clampDate,
     isInRange,
-    MAX_VALID_DATE,
-    MIN_VALID_DATE,
+    getMaxValidDate,
+    getMinValidDate,
     today,
 } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
@@ -118,8 +118,8 @@ const numberRange = (min, max) => [...Array(max - min)].map((_, i) => i + min);
 const parseLimitDate = (value, defaultValue) =>
     clampDate(
         value === "today" ? today() : value || defaultValue,
-        MIN_VALID_DATE,
-        MAX_VALID_DATE,
+        getMinValidDate(),
+        getMaxValidDate(),
     );
 
 /**
@@ -449,8 +449,8 @@ export class DateTimePicker extends Component {
             props.maxPrecision,
         );
 
-        this.maxDate = parseLimitDate(props.maxDate, MAX_VALID_DATE);
-        this.minDate = parseLimitDate(props.minDate, MIN_VALID_DATE);
+        this.maxDate = parseLimitDate(props.maxDate, getMaxValidDate());
+        this.minDate = parseLimitDate(props.minDate, getMinValidDate());
         if (this.props.type === "date") {
             this.maxDate = this.maxDate.endOf("day");
             this.minDate = this.minDate.startOf("day");

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -48,9 +48,15 @@ const { DateTime, Settings } = /** @type {any} */ (globalThis.luxon ?? {});
 
 /**
  * Limits defining a valid date (server only understands 4-digit years).
+ * Lazily initialized to avoid crashing when luxon is not yet loaded
+ * (e.g. in standalone asset bundles like survey.survey_assets).
  */
-export const MIN_VALID_DATE = DateTime.fromObject({ year: 1000 });
-export const MAX_VALID_DATE = DateTime.fromObject({ year: 9999 }).endOf("year");
+export function getMinValidDate() {
+    return DateTime.fromObject({ year: 1000 });
+}
+export function getMaxValidDate() {
+    return DateTime.fromObject({ year: 9999 }).endOf("year");
+}
 
 const nonAlphaRegex = /[^a-z]/gi;
 const nonDigitRegex = /[^\d]/g;
@@ -110,7 +116,7 @@ export class ConversionError extends Error {
  * @param {NullableDateTime} date
  */
 function isValidDate(date) {
-    return date && date.isValid && isInRange(date, [MIN_VALID_DATE, MAX_VALID_DATE]);
+    return date && date.isValid && isInRange(date, [getMinValidDate(), getMaxValidDate()]);
 }
 
 /**

--- a/addons/web/static/src/public/database_manager.qweb.html
+++ b/addons/web/static/src/public/database_manager.qweb.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/web/static/src/libs/fontawesome7/css/regular.css" />
     <link rel="stylesheet" href="/web/static/src/libs/fontawesome7/css/brands.css" />
     <link rel="stylesheet" href="/web/static/lib/bootstrap/dist/css/bootstrap.css" />
-    <script type="importmap">{"imports": {"@popperjs/core": "/web/static/lib/popper/popper.esm.js"}}</script>
+    <script type="importmap">{"imports": {"@popperjs/core": "/web/static/lib/popper/popper.esm.js", "bootstrap": "/web/static/lib/bootstrap/bootstrap.esm.js"}}</script>
     <script type="module" src="/web/static/lib/bootstrap/bootstrap.esm.js"></script>
 
     <script>
@@ -20,7 +20,7 @@
             document.documentElement.setAttribute("data-bs-theme", dark ? "dark" : "light");
         })();
     </script>
-    <script src="/web/static/src/public/database_manager.js" ></script>
+    <script type="module" src="/web/static/src/public/database_manager.js" ></script>
     <style>
         a {
             text-decoration: none;


### PR DESCRIPTION
## Summary

Hotfixes found uncommitted on production server (`/tmp/core-uncommitted.diff`).
Three of the seven changes were already committed; the remaining four are in this PR.

- **purchase**: `button_cancel()` → `action_cancel()` on draft invoices — the old method
  no longer exists in v19 `account.move`, causing AttributeError on PO cancellation
- **web/dates.js**: convert `MIN_VALID_DATE` / `MAX_VALID_DATE` module-level constants
  to lazy getter functions — avoids crash when luxon is not yet loaded (survey standalone assets)
- **web/datetime_picker.js**: consume the new getter functions
- **web/database_manager.qweb.html**: add `bootstrap` to importmap + `type="module"` on
  script tag — required since `database_manager.js` now uses ES module imports

## Verification

- [x] Cancel a purchase order that has draft invoices — no AttributeError
- [x] Open survey in standalone mode — no luxon crash on date picker
- [x] Open `/web/database/manager` — page loads, modals work