### PR TITLE
[IMP] base_sql_report, base_vat, odoo: quality cleanup

### DIFF
--- a/addons/base_sql_report/__manifest__.py
+++ b/addons/base_sql_report/__manifest__.py
@@ -1,136 +1,69 @@
 {
     "name": "Base SQL Report",
-    "version": "19.0.1.0.0",
+    "version": "19.0.2.0.0",
     "category": "Hidden",
     "summary": "SQL report construction and materialized view mixins",
     "description": """
 Base SQL Report
 ===============
 
-This module provides foundational mixins for building SQL-based analytical
-reports using clean, registry-driven patterns.
+Mixins for building SQL-based analytical reports.
 
-Materialized View Mixin
-------------------------
-The ``materialized.view.mixin`` provides safe refresh() and helper methods for
-models backed by PostgreSQL materialized views:
+``sql.report.mixin``
+--------------------
+Registry-driven SQL construction for ``_auto = False`` models.  Subclasses
+define SELECT / FROM / WHERE / GROUP BY clauses as dicts and lists rather than
+monolithic strings; inheritance is just dict / list mutation::
 
-* **Safe refresh()**: Handles missing views during upgrades
-* **View existence checks**: ``_view_exists()`` helper method
-* **Population status**: ``_is_populated()`` helper method
-* **Concurrent refresh**: Automatic CONCURRENTLY when view is populated
-* **Error handling**: Graceful failures with logging for cron retry
-* **Auto-detection**: Works with both registry pattern (``_table_query``) and custom ``_query()``
+    def _get_select_fields(self):
+        fields = super()._get_select_fields()
+        fields["margin"] = "SUM(l.margin)"
+        return fields
 
-Usage Pattern 1 - Custom SQL with CTEs (for complex analytical queries)::
+``materialized.view.mixin``
+---------------------------
+Safe (re)creation and refresh of PostgreSQL materialized views.
 
-    class ComplexReport(models.Model):
-        _inherit = 'materialized.view.mixin'
-        _auto = False
+* Schema-scoped introspection (``current_schema::regnamespace``).
+* RESTRICT-aware drop: warns loudly with the list of dependent relations
+  before a CASCADE drop.
+* Refuses to silently overwrite a regular table with an MV of the same name.
+* ``refresh()`` falls back to blocking REFRESH on unpopulated MVs (PG rejects
+  CONCURRENTLY there) and only swallows transient errors — programming errors
+  propagate to the cron log.
+* ``with_data=True`` by default — PG18 raises ``ObjectNotInPrerequisiteState``
+  on SELECT from unpopulated MVs, so the previous default would break queries
+  until the first cron tick.
 
-        def _query(self):
-            return '''
-                WITH cte1 AS (...),
-                     cte2 AS (...)
-                SELECT ... FROM cte1 JOIN cte2 ...
-            '''
-
-        def init(self):
-            self._create_materialized_view()
-
-Usage Pattern 2 - Registry Pattern (for maintainable, extensible queries)::
-
-    class ExtensibleReport(models.Model):
-        _inherit = ['sql.report.mixin', 'materialized.view.mixin']
-        _auto = False
-
-        def _get_select_fields(self):
-            return {'id': 'MIN(l.id)', 'total': 'SUM(l.amount)'}
-
-        def _get_from_tables(self):
-            return [('sale_order_line', 'l', None, None)]
-
-        # _query() automatically uses _table_query!
-
-        def init(self):
-            self._create_materialized_view()
-
-SQL Report Mixin
-----------------
-The ``sql.report.mixin`` provides a clean inheritance pattern for SQL-based
-analytical reports (``_auto = False``) using the **Registry Pattern**:
-
-* **SELECT fields**: Dict-based registry - easy add/modify/remove
-* **FROM tables**: List-based registry - structured JOIN management
-* **WHERE conditions**: List of conditions joined with AND
-* **GROUP BY fields**: List of grouping expressions
-* **ORDER BY fields**: List of ordering expressions (optional)
-* **WITH CTEs**: Support for Common Table Expressions
-
-Based on the excellent design in addons/purchase/report/purchase_report.py
-
-Benefits vs traditional string manipulation:
-
-* Add fields: ``fields['margin'] = 'SUM(l.margin)'``
-* Modify fields: ``fields['total'] = 'CUSTOM_CALC'``
-* Remove fields: ``del fields['unwanted']``
-* Add JOINs: ``tables.append(('custom_table', 'ct', 'LEFT JOIN', 'o.id=ct.order_id'))``
-* Filter JOINs: ``[t for t in tables if t[1] != 'unwanted_alias']``
-* Add WHERE: ``conditions.append("o.state != 'cancel'")``
-* No SQL string parsing/regex required!
-
-Design Goals
-------------
-* Eliminate code duplication across analytical report modules
-* Provide clean extension points for customization via inheritance
-* Make SQL report behavior consistent and predictable
-* Improve code readability and maintainability
-* Type safety through SQL objects to prevent injection
-
-Usage Example
--------------
+Composition
+-----------
+The two mixins compose.  When both are inherited, the ``_materialized`` marker
+makes ``sql.report.mixin._table_query`` return ``None`` so the ORM reads the
+physical MV — the analytical query is no longer re-inlined as a subquery on
+every search.
 
 ::
 
     class MyReport(models.Model):
-        _name = 'my.report'
-        _inherit = 'sql.report.mixin'
-        _description = 'My Analysis Report'
+        _name = "my.report"
+        _inherit = ["sql.report.mixin", "materialized.view.mixin"]
         _auto = False
 
-        # Define fields
-        id = fields.Integer(readonly=True)
-        product_id = fields.Many2one('product.product', readonly=True)
-        total_qty = fields.Float(readonly=True)
+        def _get_select_fields(self): ...
+        def _get_from_tables(self): ...
 
-        # Implement registries
-        def _get_select_fields(self):
-            return {
-                'id': 'MIN(l.id)',
-                'product_id': 'l.product_id',
-                'total_qty': 'SUM(l.quantity)',
-            }
+        def init(self):
+            self._create_materialized_view(index_field="product_id")
 
-        def _get_from_tables(self):
-            return [
-                ('sale_order_line', 'l', None, None),
-                ('sale_order', 'o', 'LEFT JOIN', 'l.order_id=o.id'),
-            ]
-
-        def _get_where_conditions(self):
-            return ['l.display_type IS NULL']
-
-        def _get_group_by_fields(self):
-            return ['l.product_id']
-
-This module is part of an aggressive refactoring initiative for Odoo 19+ with
-no backward compatibility constraints.
+Trust contract
+--------------
+Registry values are inserted into SQL verbatim.  Never build them from
+``self.env.context`` or other untrusted sources.  For parameterized
+conditions, return an ``SQL`` object from ``_get_where_conditions`` —
+e.g. ``SQL("o.partner_id = %s", pid)``.
     """,
-    "author": "Odoo Community",
-    "website": "https://www.odoo.com",
+    "author": "AgroMarin",
+    "website": "https://www.agromarin.mx",
     "license": "LGPL-3",
-    "depends": [
-        "base",
-    ],
-
+    "depends": ["base"],
 }

--- a/addons/base_sql_report/models/sql_materialized_mixin.py
+++ b/addons/base_sql_report/models/sql_materialized_mixin.py
@@ -1,220 +1,241 @@
 import logging
 
-from odoo import models
-from odoo.tools.sql import SQL
+import psycopg
 
+from odoo import models
+from odoo.exceptions import UserError
+from odoo.tools.sql import SQL
 
 _logger = logging.getLogger(__name__)
 
 
+# Transient Postgres errors that are safe to surface as "retry on next cron".
+# Anything else (programming errors, auth, corruption) must propagate so the
+# cron's error log actually records it.
+_TRANSIENT_REFRESH_ERRORS = (
+    psycopg.errors.SerializationFailure,
+    psycopg.errors.LockNotAvailable,
+    psycopg.errors.DeadlockDetected,
+)
+
+
 class MaterializedViewMixin(models.AbstractModel):
-    """Abstract mixin for models using PostgreSQL materialized views.
+    """Abstract mixin for models backed by PostgreSQL materialized views.
 
-    This mixin provides:
-    - Safe refresh() that handles missing views during upgrades
-    - Helper methods to check view existence and population status
-    - Error handling for concurrent access during view recreation
+    Provides idempotent ``_create_materialized_view()``, safe ``refresh()`` with
+    a fallback between CONCURRENTLY and blocking variants, and a cron entry
+    point.  Introspection queries are scoped to ``current_schema`` so multi-
+    schema databases are handled correctly.
 
-    Usage:
-        class MyReport(models.Model):
-            _name = 'my.report'
-            _inherit = 'materialized.view.mixin'
-            _auto = False
+    Combining with ``sql.report.mixin``
+    -----------------------------------
+    The two mixins are designed to compose:
 
-            def _query(self):
-                return "SELECT * FROM ..."
+        _inherit = ["sql.report.mixin", "materialized.view.mixin"]
 
-            def init(self):
-                self._create_materialized_view()
+    The ``_materialized = True`` marker set by this mixin makes
+    ``sql.report.mixin._table_query`` return ``None``, so the ORM reads the
+    physical materialized view at ``self._table`` (fast) instead of inlining
+    the analytical query as a subquery (slow).  ``_create_materialized_view``
+    still uses the registry-built SQL via ``_query()`` to populate the MV.
+
+    Stand-alone usage
+    -----------------
+    When inherited without ``sql.report.mixin``, the subclass must override
+    ``_query()`` to return the defining SQL.
     """
 
     _name = "materialized.view.mixin"
     _description = "Materialized View Mixin"
 
+    # Consumed by sql.report.mixin._table_query: True makes the ORM read
+    # from the physical relation rather than re-inlining the analytical query.
+    _materialized = True
+
+    # ------------------------------------------------------------------
+    # QUERY ACCESSOR
+    # ------------------------------------------------------------------
+
     def _query(self):
-        """Return the SQL query for creating the materialized view.
+        """Return the defining ``SQL`` for the materialized view.
 
-        Automatically delegates to ``_table_query`` when the model also
-        inherits from ``sql.report.mixin``.  Otherwise, subclasses must
-        override this method to provide a ``SQL`` object directly.
+        Resolution order (so ``_inherit`` order between the two mixins doesn't
+        matter):
 
-        :returns: SQL object for the materialized view definition
-        :rtype: SQL
-        :raises NotImplementedError: if neither ``_table_query`` nor an
-            override is available
-        :raises TypeError: if ``_table_query`` returns a non-SQL object
-        :raises ValueError: if ``_table_query`` returns an empty SQL object
+        1. ``_build_table_query`` if present — from ``sql.report.mixin``.
+        2. ``_table_query`` attribute if it's a non-empty ``SQL`` or ``str``.
+        3. Otherwise raise ``NotImplementedError``.
+
+        Stand-alone usage (no ``sql.report.mixin``) requires overriding this
+        method.
         """
-        if hasattr(self, "_table_query"):
-            # Model inherits sql.report.mixin - use registry pattern
-            sql_obj = self._table_query
-            if not isinstance(sql_obj, SQL):
-                # _table_query exists but returns wrong type
-                raise TypeError(
-                    f"{self._name}._table_query must return a SQL object, "
-                    f"got {type(sql_obj).__name__}: {sql_obj!r}",
-                )
-            if not sql_obj:  # Empty SQL object (bool(SQL("")) is False)
-                raise ValueError(
-                    f"{self._name}._table_query returned an empty SQL object",
-                )
-            # Return SQL object directly - don't render to string
-            return sql_obj
-        # No registry pattern - subclass must override
+        build = getattr(self, "_build_table_query", None)
+        if callable(build):
+            sql_obj = build()
+            if isinstance(sql_obj, SQL) and sql_obj:
+                return sql_obj
+        table_query = getattr(self, "_table_query", None)
+        if isinstance(table_query, SQL) and table_query:
+            return table_query
+        if isinstance(table_query, str) and table_query:
+            return SQL(table_query)
         raise NotImplementedError(
-            f"{self._name}: Either inherit 'sql.report.mixin' to use the registry "
-            "pattern, or override _query() method to provide SQL manually.",
+            f"{self._name}: override _query() to return a non-empty SQL object, "
+            "or inherit 'sql.report.mixin' for the registry pattern."
         )
 
-    def _view_exists(self, table):
-        """Check if the materialized view exists in the database.
+    # ------------------------------------------------------------------
+    # POSTGRES INTROSPECTION (schema-scoped)
+    # ------------------------------------------------------------------
 
-        Args:
-            table: Name of the table to check
-
-        Returns:
-            bool: True if the materialized view exists, False otherwise
-        """
+    def _view_exists(self, table) -> bool:
+        """True if a materialized view named ``table`` exists in the current schema."""
         self.env.cr.execute(
-            SQL("SELECT 1 FROM pg_class WHERE relname = %s and relkind = 'm'", table),
+            SQL(
+                "SELECT 1 FROM pg_class "
+                "WHERE relname = %s "
+                "AND relkind = 'm' "
+                "AND relnamespace = current_schema::regnamespace",
+                table,
+            )
         )
         return bool(self.env.cr.fetchone())
 
-    def _is_populated(self, table):
-        """Check if the materialized view is populated with data.
-
-        Args:
-            table: Name of the table to check
-
-        Returns:
-            bool: True if the view is populated, False otherwise
-        """
+    def _is_populated(self, table) -> bool:
+        """True if the materialized view ``table`` has been populated with data."""
         self.env.cr.execute(
             SQL(
-                "SELECT relispopulated FROM pg_class WHERE relname = %s and relkind = 'm'",
+                "SELECT relispopulated FROM pg_class "
+                "WHERE relname = %s "
+                "AND relkind = 'm' "
+                "AND relnamespace = current_schema::regnamespace",
                 table,
-            ),
+            )
         )
-        res = self.env.cr.fetchone()
-        return res and res[0]
+        row = self.env.cr.fetchone()
+        return bool(row and row[0])
 
-    def refresh(self):
-        """Refresh the materialized view with current data.
+    def _relkind(self, table):
+        """Return ``pg_class.relkind`` for ``table`` in the current schema, or None."""
+        self.env.cr.execute(
+            SQL(
+                "SELECT relkind FROM pg_class "
+                "WHERE relname = %s "
+                "AND relnamespace = current_schema::regnamespace",
+                table,
+            )
+        )
+        row = self.env.cr.fetchone()
+        return row[0] if row else None
 
-        This method safely refreshes the materialized view, handling cases where:
-        - The view doesn't exist yet (during module upgrade)
-        - The view exists but is not populated
-        - The view is populated and can be refreshed concurrently
+    def _dependent_relations(self, table) -> list:
+        """List views / matviews that depend on ``table`` (would be dropped by CASCADE)."""
+        self.env.cr.execute(
+            SQL(
+                """
+            SELECT DISTINCT c2.relname, c2.relkind
+            FROM pg_depend d
+            JOIN pg_class c1 ON d.refobjid = c1.oid
+            JOIN pg_rewrite r ON d.objid = r.oid
+            JOIN pg_class c2 ON r.ev_class = c2.oid
+            WHERE c1.relname = %s
+              AND c1.relnamespace = current_schema::regnamespace
+              AND c2.relname != c1.relname
+            """,
+                table,
+            )
+        )
+        return list(self.env.cr.fetchall())
 
-        The CONCURRENTLY option allows queries against the materialized view
-        while it's being refreshed, but requires the view to be populated first
-        and to have a unique index.
+    # ------------------------------------------------------------------
+    # REFRESH
+    # ------------------------------------------------------------------
 
-        Returns:
-            bool: True if refresh succeeded, False if skipped
+    def refresh(self) -> bool:
+        """Refresh the materialized view.
+
+        Falls back to a blocking (non-concurrent) refresh on the first call
+        because PostgreSQL rejects CONCURRENTLY on unpopulated MVs with
+        ``FeatureNotSupported``.
+
+        Returns True on success, False if the view doesn't exist or a
+        transient error occurred.  Non-transient errors propagate so the
+        cron's error log actually shows them.
         """
-        # Check if the view exists before trying to refresh
         if not self._view_exists(self._table):
-            # View doesn't exist yet - this can happen during module upgrade
-            # when init() drops and recreates the view
             _logger.warning(
-                "Materialized view %s does not exist. "
-                "Skipping refresh. Run init() to create the view.",
+                "Materialized view %s does not exist — skipping refresh. "
+                "Run init() to create it.",
                 self._table,
             )
             return False
 
-        # Refresh the view
-        # Use CONCURRENTLY if the view is already populated to avoid locking
+        table_name = SQL.identifier(self._table)
         try:
-            is_populated = self._is_populated(self._table)
-            table_name = SQL.identifier(self._table)
-
-            if is_populated:
-                _logger.info(
-                    "Refreshing materialized view %s (concurrently)", self._table
-                )
+            if self._is_populated(self._table):
+                _logger.info("Refreshing %s (CONCURRENTLY)", self._table)
                 self.env.cr.execute(
                     SQL("REFRESH MATERIALIZED VIEW CONCURRENTLY %s", table_name),
                 )
             else:
-                _logger.info("Refreshing materialized view %s (with lock)", self._table)
+                _logger.info("Refreshing %s (blocking, first refresh)", self._table)
                 self.env.cr.execute(
                     SQL("REFRESH MATERIALIZED VIEW %s", table_name),
                 )
-            return True
-        except Exception as e:
-            # Log the error but don't crash - the cron will retry later
-            _logger.error(
-                "Failed to refresh materialized view %s: %s. "
-                "Will retry on next cron run.",
+        except _TRANSIENT_REFRESH_ERRORS as exc:
+            _logger.warning(
+                "Transient refresh failure on %s: %s. Cron will retry.",
                 self._table,
-                e,
+                exc,
             )
             return False
+        return True
 
-    def _cron_refresh_materialized_view(self):
-        """Cron job wrapper to refresh the materialized view.
-
-        This method provides a consistent API for cron jobs across all models
-        that inherit from this mixin. It simply delegates to refresh().
-
-        Returns:
-            bool: True if refresh succeeded, False if skipped or failed
-        """
+    def _cron_refresh_materialized_view(self) -> bool:
+        """Cron entry point.  Thin wrapper around ``refresh()``."""
         return self.refresh()
 
-    def _create_materialized_view(self, with_data=False, index_field=None):
-        """Create or recreate the materialized view with unique index.
+    # ------------------------------------------------------------------
+    # CREATION
+    # ------------------------------------------------------------------
 
-        This is a helper method that can be called from init() to standardize
-        materialized view creation across all report models.
+    def _create_materialized_view(self, with_data=True, index_field="id"):
+        """(Re)create the materialized view and its unique index.
 
         Args:
-            with_data: bool, if True creates the view WITH DATA (populated),
-                      if False creates WITH NO DATA (empty, faster for upgrades)
-            index_field: str, field name for unique index. If None, uses 'id'.
-                        Required for CONCURRENT refresh to work.
+            with_data: If True (default), populate immediately (``WITH DATA``).
+                Default changed from False — PostgreSQL rejects SELECT on
+                unpopulated MVs with ``ObjectNotInPrerequisiteState``, which
+                would make reports fail hard between install and first cron
+                refresh.  Pass ``with_data=False`` only for MVs so large that
+                install latency outweighs availability, and queue a refresh
+                immediately after module install.
+            index_field: Column for the UNIQUE index required by REFRESH
+                MATERIALIZED VIEW CONCURRENTLY.  Defaults to ``"id"``.
 
-        Note:
-            Subclasses must implement _query() method that returns a SQL object.
-            The unique index enables REFRESH MATERIALIZED VIEW CONCURRENTLY.
+        Raises:
+            UserError: if ``self._table`` is already used by a regular table
+                or any relation kind other than view / materialized view.
         """
         table_name = SQL.identifier(self._table)
-        query_sql = self._query()  # Returns SQL object
+        query_sql = self._query()
+        if not isinstance(query_sql, SQL) or not query_sql:
+            raise TypeError(
+                f"{self._name}._query() must return a non-empty SQL object, "
+                f"got {type(query_sql).__name__}: {query_sql!r}",
+            )
 
-        # Determine index field (default to 'id')
-        if index_field is None:
-            index_field = "id"
+        self._drop_existing_relation(table_name)
 
-        # Drop existing view/materialized view if it exists
-        # Handle migration from regular VIEW (sql.report.mixin) to MATERIALIZED VIEW
-        # PostgreSQL: relkind 'v' = view, 'm' = materialized view
-        self.env.cr.execute(
-            "SELECT relkind FROM pg_class WHERE relname = %s", (self._table,)
-        )
-        result = self.env.cr.fetchone()
-        if result:
-            if result[0] == "v":
-                _logger.info(
-                    "Dropping regular view %s (migration to materialized)", self._table
-                )
-                self.env.cr.execute(SQL("DROP VIEW IF EXISTS %s CASCADE", table_name))
-            elif result[0] == "m":
-                _logger.info("Dropping materialized view %s", self._table)
-                self.env.cr.execute(
-                    SQL("DROP MATERIALIZED VIEW IF EXISTS %s CASCADE", table_name)
-                )
-
-        # Create the view - compose SQL objects using parameter substitution
         if with_data:
             _logger.info("Creating materialized view %s WITH DATA", self._table)
             self.env.cr.execute(
                 SQL("CREATE MATERIALIZED VIEW %s AS %s", table_name, query_sql),
             )
         else:
-            _logger.info(
-                "Creating materialized view %s WITH NO DATA (will be populated by cron)",
+            _logger.warning(
+                "Creating %s WITH NO DATA — SELECT on this MV will raise "
+                "ObjectNotInPrerequisiteState until the first refresh().",
                 self._table,
             )
             self.env.cr.execute(
@@ -225,11 +246,11 @@ class MaterializedViewMixin(models.AbstractModel):
                 ),
             )
 
-        # Create unique index for concurrent refresh support
         index_name = SQL.identifier(f"id_{self._table}")
         index_field_sql = SQL.identifier(index_field)
         _logger.info(
-            "Creating unique index on %s.%s for concurrent refresh",
+            "Creating unique index id_%s on %s(%s)",
+            self._table,
             self._table,
             index_field,
         )
@@ -241,3 +262,45 @@ class MaterializedViewMixin(models.AbstractModel):
                 index_field_sql,
             ),
         )
+
+    def _drop_existing_relation(self, table_name_sql):
+        """Drop an existing view / materialized view safely.
+
+        Warns loudly when dependent objects would be CASCADE-dropped; refuses
+        to proceed when the name is used by a regular table (data-loss risk).
+        """
+        kind = self._relkind(self._table)
+        if kind is None:
+            return
+        if kind in ("r", "p"):
+            raise UserError(
+                f"Cannot create materialized view {self._table!r}: a regular "
+                f"table with that name already exists (relkind={kind!r}). "
+                "Drop or rename it manually before upgrading the module."
+            )
+        if kind not in ("v", "m"):
+            raise UserError(
+                f"Cannot (re)create materialized view {self._table!r}: "
+                f"unexpected pg_class relkind {kind!r}.  Investigate manually."
+            )
+
+        dependents = self._dependent_relations(self._table)
+        if dependents:
+            _logger.warning(
+                "Dropping %s %s will CASCADE %d dependent relation(s): %s",
+                "materialized view" if kind == "m" else "view",
+                self._table,
+                len(dependents),
+                [f"{name} (kind={relkind})" for name, relkind in dependents],
+            )
+
+        if kind == "v":
+            _logger.info(
+                "Dropping regular view %s (migration to materialized)", self._table
+            )
+            self.env.cr.execute(SQL("DROP VIEW IF EXISTS %s CASCADE", table_name_sql))
+        else:
+            _logger.info("Dropping materialized view %s", self._table)
+            self.env.cr.execute(
+                SQL("DROP MATERIALIZED VIEW IF EXISTS %s CASCADE", table_name_sql),
+            )

--- a/addons/base_sql_report/models/sql_report_mixin.py
+++ b/addons/base_sql_report/models/sql_report_mixin.py
@@ -3,431 +3,303 @@ from odoo.tools.sql import SQL
 
 
 class SqlReportMixin(models.AbstractModel):
-    """Mixin for SQL-based analytical reports with registry-driven construction.
+    """Registry-driven SQL construction for analytical reports.
 
-    This mixin provides a clean inheritance pattern for Odoo SQL reports (_auto = False)
-    where SQL clauses are built from structured registries (dicts/lists) rather than
-    string manipulation. This makes reports much easier to extend via inheritance.
+    This mixin builds the ``FROM`` expression of ``_auto = False`` reports from
+    structured registries (dicts for SELECT, lists for FROM / WHERE / GROUP /
+    ORDER) rather than from string-manipulation of monolithic SQL methods.
+    Subclasses add, modify, or remove entries via normal dict / list operations.
 
-    Design Philosophy
-    -----------------
-    Traditional Odoo reports build SQL using monolithic methods that return complete
-    clauses (e.g., "_select_sale() returns 'SELECT ... AS id, ...'"). This makes
-    inheritance difficult because you need string manipulation to modify the SQL.
+    Composition with ``materialized.view.mixin``
+    --------------------------------------------
+    When a model also inherits ``materialized.view.mixin``, its ``_materialized``
+    class attribute is True.  ``_table_query`` then returns ``None`` so the ORM
+    reads from the physical materialized view at ``self._table`` instead of
+    inlining the query as a subquery.  ``_build_table_query()`` is still used to
+    populate the MV via ``_create_materialized_view()``.
 
-    This mixin uses the **Registry Pattern** where each clause is built from structured
-    data (dicts for SELECT, lists for FROM/WHERE/GROUP BY). Inheriting modules simply
-    modify the registry data structures - no SQL string parsing required.
+    Trust contract for registry values
+    ----------------------------------
+    Every string returned by the ``_get_*`` methods is inserted into SQL
+    verbatim — there is no parameter binding.  **Never** build registry values
+    from ``self.env.context``, request data, or any other untrusted source.
+    For parameterized conditions, return a ``SQL`` object directly (supported
+    in ``_get_where_conditions``) — e.g. ``SQL("o.partner_id = %s", partner_id)``.
 
-    Based on the excellent design in addons/purchase/report/purchase_report.py
+    Registry hooks (override these)
+    -------------------------------
+    - ``_get_select_fields() -> dict``  : ``{field_name: sql_expression}``
+    - ``_get_from_tables()  -> list``   : ``[(table, alias, join_type, on)]``
+    - ``_get_where_conditions() -> list``  : ``[str | SQL]``
+    - ``_get_group_by_fields()  -> list``  : ``[str]``
+    - ``_get_order_by_fields()  -> list``  : ``[str]``
+    - ``_with_cte() -> SQL`` (optional, default ``SQL.EMPTY``)
 
-    Architecture
-    ------------
-    1. **Registry Methods** (_get_*): Return structured data (dict/list)
-       - _get_select_fields() → dict: {field_name: sql_expression}
-       - _get_from_tables() → list: [(table, alias, join_type, on_condition)]
-       - _get_where_conditions() → list: [condition_string]
-       - _get_group_by_fields() → list: [field_expression]
-       - _get_order_by_fields() → list: [field_expression]  (optional)
-       - _with_cte() → SQL: CTE definition (optional)
+    Example
+    -------
+    ::
 
-    2. **Builder Methods** (_select, _from, _where, _group_by, _order_by):
-       - Called by _table_query to construct SQL from registries
-       - Handle formatting, SQL object creation, and joining
-       - Generally should NOT be overridden (override registries instead)
+        class MyReport(models.Model):
+            _name = "my.report"
+            _inherit = "sql.report.mixin"
+            _auto = False
 
-    3. **Main Query Method** (_table_query):
-       - Property that assembles final SQL from builder methods
-       - Handles optional clauses (WITH, WHERE, ORDER BY)
-       - Should NOT be overridden unless you need custom assembly logic
+            product_id = fields.Many2one("product.product", readonly=True)
+            total_qty = fields.Float(readonly=True)
 
-    Usage Example
-    -------------
-    class MyReport(models.Model):
-        _name = 'my.report'
-        _inherit = 'sql.report.mixin'
-        _description = 'My Analysis Report'
-        _auto = False
+            def _get_select_fields(self):
+                return {
+                    "id": "MIN(l.id)",
+                    "product_id": "l.product_id",
+                    "total_qty": "SUM(l.quantity)",
+                }
 
-        # Define fields
-        id = fields.Integer(readonly=True)
-        product_id = fields.Many2one('product.product', readonly=True)
-        total_qty = fields.Float(readonly=True)
+            def _get_from_tables(self):
+                return [
+                    ("sale_order_line", "l", None, None),
+                    ("sale_order", "o", "LEFT JOIN", "l.order_id = o.id"),
+                ]
 
-        # Implement registries
-        def _get_select_fields(self):
-            return {
-                'id': 'MIN(l.id)',
-                'product_id': 'l.product_id',
-                'total_qty': 'SUM(l.quantity)',
-            }
+            def _get_where_conditions(self):
+                return ["l.display_type IS NULL"]
 
-        def _get_from_tables(self):
-            return [
-                ('sale_order_line', 'l', None, None),  # Base table
-                ('sale_order', 'o', 'LEFT JOIN', 'l.order_id=o.id'),
-            ]
-
-        def _get_where_conditions(self):
-            return ['l.display_type IS NULL']
-
-        def _get_group_by_fields(self):
-            return ['l.product_id']
-
-    Inheritance Example
-    -------------------
-    class MyReportInherit(models.Model):
-        _inherit = 'my.report'
-
-        margin = fields.Monetary(readonly=True)
-
-        def _get_select_fields(self):
-            fields = super()._get_select_fields()
-            fields['margin'] = 'SUM(l.margin)'  # Add field
-            fields['total_qty'] = 'SUM(l.quantity * 2)'  # Modify field
-            return fields
-
-        def _get_where_conditions(self):
-            conditions = super()._get_where_conditions()
-            conditions.append("o.state != 'cancel'")  # Add condition
-            return conditions
-
-    Benefits
-    --------
-    Clear separation: Data (registries) vs Logic (builders)
-    Easy inheritance: Add/modify/remove via dict/list operations
-    Type safety: SQL objects prevent injection
-    Readable: Registry structure is self-documenting
-    Testable: Can unit test registries independently
-    Maintainable: No fragile string manipulation
-    Consistent: Same pattern across all reports
+            def _get_group_by_fields(self):
+                return ["l.product_id"]
     """
 
     _name = "sql.report.mixin"
     _description = "SQL Report Construction Helper"
     _auto = False
 
-    # ============================================================
-    # MAIN QUERY ASSEMBLY
-    # ============================================================
+    # ------------------------------------------------------------------
+    # PUBLIC QUERY ACCESSORS
+    # ------------------------------------------------------------------
 
-    def _query(self):
-        """Return SQL query object for compatibility with materialized.view.mixin.
+    def _build_table_query(self) -> SQL:
+        """Assemble the analytical query from all registries.
 
-        This method bridges the registry pattern with the materialized view mixin
-        by delegating to _table_query property.
+        Always returns a non-empty ``SQL`` object.  Raises
+        ``NotImplementedError`` if ``_get_select_fields`` or ``_get_from_tables``
+        are empty — those two registries are mandatory.
 
-        When used with materialized.view.mixin, this allows _create_materialized_view()
-        to work correctly by calling self._query() which delegates to _table_query.
-
-        Returns:
-            SQL: Complete SQL query built from registries
+        Do not override this method.  Override the registry hooks instead.
         """
-        return self._table_query
-
-    @property
-    def _table_query(self) -> SQL:
-        """Build complete SQL query from registries.
-
-        Assembles the final SQL query by calling builder methods in the correct
-        order and handling optional clauses (WITH, WHERE, GROUP BY, ORDER BY).
-
-        This method should rarely be overridden. Instead, customize behavior by
-        overriding registry methods (_get_select_fields, etc.).
-
-        :returns: Complete SQL query for the report view
-        :rtype: SQL
-        """
-        cte = self._with_cte()
         select = self._select()
         from_clause = self._from()
+        cte = self._with_cte()
         where = self._where()
         group_by = self._group_by()
         order_by = self._order_by()
 
-        # Build query parts (optional clauses are skipped if empty)
         parts = []
-
         if cte:
             parts.append(SQL("WITH %s", cte))
-
         parts.extend([select, from_clause])
-
-        if where:
-            parts.append(where)
-
-        if group_by:
-            parts.append(group_by)
-
-        if order_by:
-            parts.append(order_by)
-
+        parts.extend(clause for clause in (where, group_by, order_by) if clause)
         return SQL("\n").join(parts)
 
-    # ============================================================
-    # BUILDER METHODS (construct SQL from registries)
-    # ============================================================
+    @property
+    def _table_query(self):
+        """ORM table source — subquery SQL, or None when the model is materialized.
+
+        Consulted by ``BaseModel._table_sql`` (core ORM).  Returning ``None``
+        makes the ORM read ``FROM "self._table"`` (the physical relation).
+        Returning SQL makes the ORM inline ``FROM (SQL) AS "self._table"``.
+
+        ``getattr`` (not ``self._materialized``) so neither this mixin nor the
+        MRO order owns the default — the marker exists only when the MV mixin
+        explicitly sets it, regardless of ``_inherit`` order.
+        """
+        if getattr(self, "_materialized", False):
+            return None
+        return self._build_table_query()
+
+    def _query(self):
+        """Return the assembled SQL for materialized-view creation.
+
+        Called by ``materialized.view.mixin._create_materialized_view``.
+        Always returns the assembled query (independent of ``_materialized``
+        — this is the SQL that DEFINES the MV, not what the ORM reads from it).
+        """
+        return self._build_table_query()
+
+    # ------------------------------------------------------------------
+    # BUILDER METHODS (do not override)
+    # ------------------------------------------------------------------
 
     def _with_cte(self) -> SQL:
-        """Return CTE definition for the WITH clause (without the WITH keyword).
+        """Common Table Expression (body only, no WITH keyword).
 
-        Override to add Common Table Expressions. The mixin prepends ``WITH``
-        automatically. Return empty ``SQL("")`` for no CTE (default).
-
-        If you need multiple CTEs, separate them with commas inside the
-        returned SQL object.
-
-        :returns: CTE definition, or empty SQL for no CTE
-        :rtype: SQL
+        Default empty.  Override to return ``SQL("cte_name AS (...), ...")``.
         """
-        return SQL("")
+        return SQL.EMPTY
 
     def _select(self) -> SQL:
-        """Build SELECT clause from field registry.
-
-        Constructs the SELECT clause by iterating over the field registry and
-        formatting each field as "expression AS field_name".
-
-        Do NOT override this method. Instead, override _get_select_fields() to
-        customize the field list.
-
-        Returns:
-            SQL: SELECT clause with all fields, nicely formatted
-
-        Example Output:
-            SELECT
-                MIN(l.id) AS id,
-                l.product_id AS product_id,
-                SUM(l.quantity) AS total_qty
-        """
+        """Build the ``SELECT`` clause from the field registry."""
         fields = self._get_select_fields()
-
+        if not fields:
+            raise NotImplementedError(
+                f"{self._name}: override _get_select_fields() to return a "
+                "non-empty {field_name: sql_expression} mapping."
+            )
         field_parts = []
         for field_name, expression in fields.items():
+            self._check_percent_escaping(expression, f"select[{field_name!r}]")
             field_parts.append(
                 SQL("%s AS %s", SQL(expression), SQL.identifier(field_name)),
             )
-
         return SQL("SELECT\n    %s", SQL(",\n    ").join(field_parts))
 
     def _from(self) -> SQL:
-        """Build FROM clause from table registry.
-
-        Constructs the FROM clause with base table and all JOINs by iterating over
-        the table registry. Handles both string table names and SQL objects
-        (for currency tables, subqueries, etc.).
-
-        Do NOT override this method. Instead, override _get_from_tables() to
-        customize tables and joins.
-
-        Returns:
-            SQL: FROM clause with all JOINs, nicely formatted
-
-        Example Output:
-            FROM
-                sale_order_line l
-                LEFT JOIN sale_order o ON l.order_id=o.id
-                LEFT JOIN res_partner p ON o.partner_id=p.id
-        """
+        """Build the ``FROM`` clause from the table registry."""
         tables = self._get_from_tables()
+        if not tables:
+            raise NotImplementedError(
+                f"{self._name}: override _get_from_tables() to return a "
+                "non-empty list of (table, alias, join_type, on_condition) tuples."
+            )
         from_parts = []
-
         for table_name, alias, join_type, on_condition in tables:
-            if join_type is None:
-                # Base table (first FROM clause)
-                if alias:
-                    table_sql = (
-                        table_name if isinstance(table_name, SQL) else SQL(table_name)
-                    )
-                    from_parts.append(SQL("%s %s", table_sql, SQL(alias)))
-                else:
-                    from_parts.append(
-                        table_name if isinstance(table_name, SQL) else SQL(table_name),
-                    )
-            else:
-                # JOIN clause
-                if isinstance(table_name, SQL):
-                    # SQL object (e.g., currency_table) - use as-is
-                    if on_condition:
-                        from_parts.append(
-                            SQL(
-                                "%s %s ON %s",
-                                SQL(join_type),
-                                table_name,
-                                SQL(on_condition),
-                            ),
-                        )
-                    else:
-                        from_parts.append(SQL("%s %s", SQL(join_type), table_name))
-                else:
-                    # String table name - add alias
-                    table_sql = SQL(table_name)
-                    alias_sql = SQL(alias) if alias else SQL("")
-                    if on_condition:
-                        from_parts.append(
-                            SQL(
-                                "%s %s %s ON %s",
-                                SQL(join_type),
-                                table_sql,
-                                alias_sql,
-                                SQL(on_condition),
-                            ),
-                        )
-                    else:
-                        from_parts.append(
-                            SQL("%s %s %s", SQL(join_type), table_sql, alias_sql),
-                        )
-
+            from_parts.append(
+                self._build_from_entry(table_name, alias, join_type, on_condition)
+            )
         return SQL("FROM\n    %s", SQL("\n    ").join(from_parts))
 
+    def _build_from_entry(self, table_name, alias, join_type, on_condition) -> SQL:
+        """Render a single ``(table, alias, join_type, on)`` entry.
+
+        Base table (``join_type is None``) → ``<table> [<alias>]``.
+        JOIN entry → ``<join_type> <table> [<alias>] [ON <condition>]``.
+        When ``table_name`` is a ``SQL`` object (e.g. a currency-rate CTE) its
+        alias is assumed to be embedded already and the ``alias`` argument is
+        ignored on JOIN entries.
+        """
+        is_sql_obj = isinstance(table_name, SQL)
+        if join_type is None:
+            table_sql = table_name if is_sql_obj else SQL(table_name)
+            if alias:
+                return SQL("%s %s", table_sql, SQL(alias))
+            return table_sql
+        if on_condition:
+            self._check_percent_escaping(on_condition, f"from-join[{alias!r}]")
+        if is_sql_obj:
+            if on_condition:
+                return SQL("%s %s ON %s", SQL(join_type), table_name, SQL(on_condition))
+            return SQL("%s %s", SQL(join_type), table_name)
+        table_sql = SQL(table_name)
+        alias_sql = SQL(alias) if alias else SQL.EMPTY
+        if on_condition:
+            return SQL(
+                "%s %s %s ON %s",
+                SQL(join_type),
+                table_sql,
+                alias_sql,
+                SQL(on_condition),
+            )
+        return SQL("%s %s %s", SQL(join_type), table_sql, alias_sql)
+
     def _where(self) -> SQL:
-        """Build WHERE clause from condition registry.
+        """Build the ``WHERE`` clause from the condition registry.
 
-        Constructs the WHERE clause by joining all conditions with AND.
-        Returns empty SQL if no conditions exist (optional WHERE clause).
-
-        Do NOT override this method. Instead, override _get_where_conditions()
-        to customize filter conditions.
-
-        Returns:
-            SQL: WHERE clause with all conditions, or empty SQL if no conditions
-
-        Example Output:
-            WHERE
-                l.display_type IS NULL
-                AND o.state != 'cancel'
-                AND o.amount_total > 0
+        Accepts both strings (wrapped in ``SQL(...)``) and ``SQL`` objects
+        (inserted as-is).  Use ``SQL`` objects for parameterized conditions.
         """
         conditions = self._get_where_conditions()
-
         if not conditions:
-            return SQL("")
-
-        condition_parts = [SQL(cond) for cond in conditions]
+            return SQL.EMPTY
+        condition_parts = []
+        for cond in conditions:
+            if isinstance(cond, SQL):
+                condition_parts.append(cond)
+            else:
+                self._check_percent_escaping(cond, "where")
+                condition_parts.append(SQL(cond))
         return SQL("WHERE\n    %s", SQL("\n    AND ").join(condition_parts))
 
     def _group_by(self) -> SQL:
-        """Build GROUP BY clause from field registry.
-
-        Constructs the GROUP BY clause by joining all field expressions.
-        Returns empty SQL if no fields exist (optional GROUP BY clause).
-
-        Do NOT override this method. Instead, override _get_group_by_fields()
-        to customize grouping fields.
-
-        Returns:
-            SQL: GROUP BY clause with all fields, or empty SQL if no fields
-
-        Example Output:
-            GROUP BY
-                l.product_id,
-                o.partner_id,
-                o.date_order
-        """
+        """Build the ``GROUP BY`` clause from the field registry."""
         fields = self._get_group_by_fields()
-
         if not fields:
-            return SQL("")
-
-        field_parts = [SQL(field) for field in fields]
+            return SQL.EMPTY
+        field_parts = []
+        for field in fields:
+            self._check_percent_escaping(field, "group_by")
+            field_parts.append(SQL(field))
         return SQL("GROUP BY\n    %s", SQL(",\n    ").join(field_parts))
 
     def _order_by(self) -> SQL:
-        """Build ORDER BY clause from field registry.
+        """Build the ``ORDER BY`` clause from the field registry.
 
-        Constructs the ORDER BY clause by joining all field expressions.
-        Returns empty SQL if no fields exist (optional ORDER BY clause).
-
-        Do NOT override this method. Instead, override _get_order_by_fields()
-        to customize sort order.
-
-        Returns:
-            SQL: ORDER BY clause with all fields, or empty SQL if no fields
-
-        Example Output:
-            ORDER BY
-                o.date_order DESC,
-                o.id
-
-        Note:
-            Usually not needed - use the _order class attribute instead.
-            Only use this for complex ORDER BY that can't be expressed in _order.
+        Usually the ``_order`` class attribute is what you want — that
+        controls Python-side record ordering.  Use this hook only when the
+        defining query needs an explicit ``ORDER BY`` at creation time.
         """
         fields = self._get_order_by_fields()
-
         if not fields:
-            return SQL("")
-
-        field_parts = [SQL(field) for field in fields]
+            return SQL.EMPTY
+        field_parts = []
+        for field in fields:
+            self._check_percent_escaping(field, "order_by")
+            field_parts.append(SQL(field))
         return SQL("ORDER BY\n    %s", SQL(",\n    ").join(field_parts))
 
-    # ============================================================
-    # REGISTRY METHODS (override these in subclass)
-    # ============================================================
+    # ------------------------------------------------------------------
+    # REGISTRY HOOKS (override in subclass)
+    # ------------------------------------------------------------------
 
     def _get_select_fields(self) -> dict:
-        """Return field registry for the SELECT clause.
+        """Return ``{field_name: sql_expression}`` for the SELECT clause.
 
-        Override to define report fields as ``{field_name: sql_expression}``.
-        Dictionary order is preserved in the generated SQL.  Inheriting
-        modules add, modify, or remove entries via standard dict operations.
-
-        :returns: mapping of field names to SQL expressions
-        :rtype: dict
+        Mandatory override.  Dictionary insertion order is preserved in the
+        generated SQL.  Expressions are raw SQL — see the class-level trust
+        contract.
         """
         return {}
 
     def _get_from_tables(self) -> list:
-        """Return table registry for the FROM clause.
+        """Return the FROM-clause registry.
 
-        Override to define tables and JOINs as a list of 4-tuples
-        ``(table_name, alias, join_type, on_condition)``.  The first entry
-        is the base table (``join_type=None``); subsequent entries are JOINs.
-        ``table_name`` may be a string or a ``SQL`` object (for subqueries).
-
-        Inheriting modules append, insert, or filter the list.
-
-        :returns: list of ``(table_name, alias, join_type, on_condition)`` tuples
-        :rtype: list
+        Mandatory override.  Each entry is a 4-tuple
+        ``(table_name, alias, join_type, on_condition)``.  The first entry is
+        the base table (``join_type=None``); subsequent entries are JOINs.
+        ``table_name`` may be a string or a ``SQL`` object (e.g. subquery).
         """
         return []
 
     def _get_where_conditions(self) -> list:
-        """Return condition registry for the WHERE clause.
+        """Return filter conditions for the WHERE clause.
 
-        Override to define filter conditions as a list of SQL condition
-        strings.  All conditions are joined with ``AND``.  Use parentheses
-        for ``OR`` groups inside a single condition string.
-
-        Inheriting modules append, filter, or replace entries in the list.
-
-        :returns: list of SQL condition strings
-        :rtype: list
+        Each element may be a string (inserted verbatim) or a ``SQL`` object
+        (parameterized).  All conditions are joined with ``AND``.
         """
         return []
 
     def _get_group_by_fields(self) -> list:
-        """Return field registry for the GROUP BY clause.
-
-        Override to list all non-aggregated field expressions that must
-        appear in ``GROUP BY``.  Fields using aggregate functions (SUM, AVG,
-        MIN, MAX, COUNT) should **not** be included here.
-
-        Inheriting modules append, filter, or reorder entries in the list.
-
-        :returns: list of field expressions for GROUP BY
-        :rtype: list
-        """
+        """Return non-aggregated field expressions for the GROUP BY clause."""
         return []
 
     def _get_order_by_fields(self) -> list:
-        """Return field registry for the ORDER BY clause (optional).
-
-        Override to define custom sort expressions with direction (ASC/DESC).
-        Most reports should use the ``_order`` class attribute instead; only
-        use this for ORDER BY logic that requires runtime evaluation.
-
-        :returns: list of field expressions with sort direction
-        :rtype: list
-        """
+        """Return sort expressions for the ORDER BY clause (optional)."""
         return []
+
+    # ------------------------------------------------------------------
+    # SAFETY
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_percent_escaping(expr, location):
+        """Reject un-escaped ``%`` in registry strings.
+
+        The ``SQL()`` constructor validates format-string shape via
+        ``code % ()`` at build time.  A naive ``LIKE '%pattern%'`` therefore
+        fails with a cryptic ``TypeError: not enough arguments for format
+        string``.  Catch it here with a message that points at the offending
+        registry slot.
+        """
+        if not isinstance(expr, str) or "%" not in expr:
+            return
+        if "%" in expr.replace("%%", ""):
+            raise ValueError(
+                f"sql.report.mixin: un-escaped '%' in {location}: {expr!r}. "
+                "Use '%%' for literal percent (e.g. LIKE '%%x%%')."
+            )

--- a/addons/base_sql_report/tests/__init__.py
+++ b/addons/base_sql_report/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_sql_report_mixin
+from . import test_materialized_view_mixin

--- a/addons/base_sql_report/tests/test_materialized_view_mixin.py
+++ b/addons/base_sql_report/tests/test_materialized_view_mixin.py
@@ -1,0 +1,143 @@
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase
+from odoo.tools.sql import SQL
+
+
+class TestIntrospection(TransactionCase):
+    """Schema-scoped pg_class lookups (H3, H4 regression fences)."""
+
+    def setUp(self):
+        super().setUp()
+        self.mixin = self.env["materialized.view.mixin"]
+        self.env.cr.execute("CREATE SCHEMA IF NOT EXISTS test_bsr_schema")
+        self.env.cr.execute("""
+            DROP MATERIALIZED VIEW IF EXISTS test_bsr_schema.test_bsr_mv CASCADE
+        """)
+        self.env.cr.execute("""
+            CREATE MATERIALIZED VIEW test_bsr_schema.test_bsr_mv AS SELECT 1 AS id
+        """)
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self):
+        self.env.cr.execute(
+            "DROP MATERIALIZED VIEW IF EXISTS test_bsr_schema.test_bsr_mv CASCADE"
+        )
+        self.env.cr.execute("DROP SCHEMA IF EXISTS test_bsr_schema CASCADE")
+
+    def test_view_exists_is_schema_scoped(self):
+        # MV lives in test_bsr_schema, not public. Lookup for the unqualified
+        # name from the public-schema cursor must not match.
+        self.assertFalse(self.mixin._view_exists("test_bsr_mv"))
+
+    def test_is_populated_returns_bool_for_missing(self):
+        r = self.mixin._is_populated("obviously_missing_relation_xyz")
+        self.assertIs(type(r), bool)
+        self.assertFalse(r)
+
+    def test_relkind_returns_char_or_none(self):
+        self.assertIsNone(self.mixin._relkind("obviously_missing_relation_xyz"))
+
+
+class TestRefreshGuards(TransactionCase):
+    """refresh() behaviour under adverse conditions (M1 regression fence)."""
+
+    def setUp(self):
+        super().setUp()
+        self.mixin = self.env["materialized.view.mixin"]
+        self.env.cr.execute("DROP MATERIALIZED VIEW IF EXISTS test_bsr_refresh CASCADE")
+        self.env.cr.execute(
+            "CREATE MATERIALIZED VIEW test_bsr_refresh AS SELECT 1 AS id"
+        )
+        self.env.cr.execute("CREATE UNIQUE INDEX ON test_bsr_refresh (id)")
+        self.addCleanup(
+            lambda: self.env.cr.execute(
+                "DROP MATERIALIZED VIEW IF EXISTS test_bsr_refresh CASCADE"
+            ),
+        )
+
+    def test_refresh_returns_false_for_missing_view(self):
+        cls = type(self.mixin)
+        with patch.object(cls, "_table", "totally_missing_xyz", create=True):
+            self.assertFalse(self.mixin.refresh())
+
+    def test_refresh_propagates_programming_errors(self):
+        # Inject a non-transient error — must not be swallowed.
+        cls = type(self.mixin)
+        with (
+            patch.object(cls, "_table", "test_bsr_refresh", create=True),
+            patch.object(cls, "_is_populated", side_effect=KeyError("bug")),
+        ):
+            with self.assertRaises(KeyError):
+                self.mixin.refresh()
+
+
+class TestDependentHandling(TransactionCase):
+    """Creation-time dependency handling (H2 + H5 regression fence)."""
+
+    def setUp(self):
+        super().setUp()
+        self.mixin = self.env["materialized.view.mixin"]
+        self.env.cr.execute("DROP TABLE IF EXISTS test_bsr_collision CASCADE")
+        self.env.cr.execute("CREATE TABLE test_bsr_collision (id integer, name text)")
+        self.addCleanup(
+            lambda: self.env.cr.execute(
+                "DROP TABLE IF EXISTS test_bsr_collision CASCADE"
+            ),
+        )
+
+    def test_relkind_r_detected(self):
+        self.assertEqual(self.mixin._relkind("test_bsr_collision"), "r")
+
+    def test_dependent_relations_listed(self):
+        # Build a dependent view on top of another MV
+        self.env.cr.execute(
+            "DROP MATERIALIZED VIEW IF EXISTS test_bsr_dep_target CASCADE"
+        )
+        self.env.cr.execute(
+            "CREATE MATERIALIZED VIEW test_bsr_dep_target AS SELECT 1 AS id"
+        )
+        self.env.cr.execute("DROP VIEW IF EXISTS test_bsr_dep_child")
+        self.env.cr.execute(
+            "CREATE VIEW test_bsr_dep_child AS SELECT * FROM test_bsr_dep_target"
+        )
+        try:
+            deps = self.mixin._dependent_relations("test_bsr_dep_target")
+            names = {row[0] for row in deps}
+            self.assertIn("test_bsr_dep_child", names)
+        finally:
+            self.env.cr.execute("DROP VIEW IF EXISTS test_bsr_dep_child")
+            self.env.cr.execute(
+                "DROP MATERIALIZED VIEW IF EXISTS test_bsr_dep_target CASCADE"
+            )
+
+
+class TestQueryBridge(TransactionCase):
+    """_query() resolution order (C2 + stand-alone regression fence)."""
+
+    def test_query_falls_back_to_table_query_attribute(self):
+        mixin = self.env["materialized.view.mixin"]
+        cls = type(mixin)
+        with patch.object(cls, "_table_query", SQL("SELECT 1 AS id"), create=True):
+            # Ensure no _build_table_query is visible
+            with patch.object(cls, "_build_table_query", None, create=True):
+                q = mixin._query()
+                self.assertIsInstance(q, SQL)
+                self.assertEqual(q.code, "SELECT 1 AS id")
+
+    def test_query_accepts_str_table_query(self):
+        mixin = self.env["materialized.view.mixin"]
+        cls = type(mixin)
+        with patch.object(cls, "_table_query", "SELECT 1 AS id", create=True):
+            with patch.object(cls, "_build_table_query", None, create=True):
+                q = mixin._query()
+                self.assertIsInstance(q, SQL)
+                self.assertEqual(q.code, "SELECT 1 AS id")
+
+    def test_query_raises_when_no_source(self):
+        mixin = self.env["materialized.view.mixin"]
+        cls = type(mixin)
+        with patch.object(cls, "_table_query", None, create=True):
+            with patch.object(cls, "_build_table_query", None, create=True):
+                with self.assertRaises(NotImplementedError):
+                    mixin._query()

--- a/addons/base_sql_report/tests/test_sql_report_mixin.py
+++ b/addons/base_sql_report/tests/test_sql_report_mixin.py
@@ -1,0 +1,199 @@
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase
+from odoo.tools.sql import SQL
+
+# ---------------------------------------------------------------------------
+# Test fixtures — tiny reports defined in-process (NOT registered in a module)
+# ---------------------------------------------------------------------------
+# We build them by subclassing directly from the abstract mixin and accessing
+# the build method — this lets us unit-test registry composition without
+# needing a physical view in the database.
+
+
+class _Harness:
+    """Helper producing a throwaway model-like object bound to sql.report.mixin."""
+
+    def __init__(
+        self,
+        env,
+        select=None,
+        from_=None,
+        where=None,
+        group_by=None,
+        order_by=None,
+        cte=None,
+    ):
+        self._env = env
+        self._select = select or {}
+        self._from = from_ or []
+        self._where = where or []
+        self._group = group_by or []
+        self._order = order_by or []
+        self._cte = cte
+
+    def __call__(self):
+        m = self._env["sql.report.mixin"]
+        # Patch the registry hooks in-place for this instance's method resolution
+        return m, self
+
+
+def _build_with_registries(env, **registries):
+    """Call _build_table_query on sql.report.mixin with patched registry hooks.
+
+    Pass registry return values directly (dicts, lists, SQL objects).  The
+    helper wraps them into bound methods on the class for the duration of the
+    call, then restores the originals.
+    """
+    mixin = env["sql.report.mixin"]
+    cls = type(mixin)
+    original = {name: getattr(cls, name) for name in registries}
+    try:
+        for name, value in registries.items():
+            setattr(cls, name, lambda self, _v=value: _v)
+        return mixin._build_table_query()
+    finally:
+        for name, method in original.items():
+            setattr(cls, name, method)
+
+
+class TestRegistryComposition(TransactionCase):
+    """Core registry-assembly behaviour."""
+
+    def test_select_and_from_assemble(self):
+        sql = _build_with_registries(
+            self.env,
+            _get_select_fields={"id": "u.id", "login": "u.login"},
+            _get_from_tables=[("res_users", "u", None, None)],
+        )
+        self.assertIn("SELECT", sql.code)
+        self.assertIn('u.id AS "id"', sql.code)
+        self.assertIn('u.login AS "login"', sql.code)
+        self.assertIn("FROM", sql.code)
+        self.assertIn("res_users u", sql.code)
+
+    def test_with_cte_preserved(self):
+        sql = _build_with_registries(
+            self.env,
+            _get_select_fields={"id": "c.id"},
+            _get_from_tables=[("my_cte", "c", None, None)],
+            _with_cte=SQL("my_cte AS (SELECT 1 AS id)"),
+        )
+        self.assertIn("WITH", sql.code)
+        self.assertIn("my_cte AS (SELECT 1 AS id)", sql.code)
+
+    def test_where_joins_with_AND(self):
+        sql = _build_with_registries(
+            self.env,
+            _get_select_fields={"id": "u.id"},
+            _get_from_tables=[("res_users", "u", None, None)],
+            _get_where_conditions=["u.active = TRUE", "u.id > 0"],
+        )
+        self.assertIn("WHERE", sql.code)
+        self.assertIn("AND", sql.code)
+
+    def test_where_accepts_SQL_objects_for_params(self):
+        sql = _build_with_registries(
+            self.env,
+            _get_select_fields={"id": "u.id"},
+            _get_from_tables=[("res_users", "u", None, None)],
+            _get_where_conditions=[SQL("u.login = %s", "admin")],
+        )
+        self.assertEqual(sql.params, ("admin",))
+
+    def test_empty_select_raises(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            _build_with_registries(
+                self.env,
+                _get_select_fields={},
+                _get_from_tables=[("res_users", "u", None, None)],
+            )
+        self.assertIn("_get_select_fields", str(cm.exception))
+
+    def test_empty_from_raises(self):
+        with self.assertRaises(NotImplementedError) as cm:
+            _build_with_registries(
+                self.env,
+                _get_select_fields={"id": "1"},
+                _get_from_tables=[],
+            )
+        self.assertIn("_get_from_tables", str(cm.exception))
+
+
+class TestPercentEscaping(TransactionCase):
+    """Registry strings must escape ``%`` as ``%%``; enforce with a clear error."""
+
+    def test_unescaped_percent_in_select_raises_value_error(self):
+        with self.assertRaises(ValueError) as cm:
+            _build_with_registries(
+                self.env,
+                _get_select_fields={
+                    "id": "u.id",
+                    "adm": "CASE WHEN u.login LIKE 'adm%' THEN 1 ELSE 0 END",
+                },
+                _get_from_tables=[("res_users", "u", None, None)],
+            )
+        self.assertIn("%%", str(cm.exception))
+        self.assertIn("adm", str(cm.exception))
+
+    def test_escaped_percent_pair_accepted(self):
+        # The SQL class preserves '%%' verbatim in .code (psycopg collapses
+        # to '%' at execution time).  What matters is that construction
+        # doesn't raise TypeError — which was the whole point of the
+        # escaping requirement.
+        sql = _build_with_registries(
+            self.env,
+            _get_select_fields={
+                "id": "u.id",
+                "adm": "CASE WHEN u.login LIKE 'adm%%' THEN 1 ELSE 0 END",
+            },
+            _get_from_tables=[("res_users", "u", None, None)],
+        )
+        self.assertIn("adm%%", sql.code)
+        self.env.cr.execute(sql)  # must not raise — round-trip through psycopg
+
+    def test_unescaped_percent_in_where_raises(self):
+        with self.assertRaises(ValueError):
+            _build_with_registries(
+                self.env,
+                _get_select_fields={"id": "u.id"},
+                _get_from_tables=[("res_users", "u", None, None)],
+                _get_where_conditions=["u.login LIKE 'x%'"],
+            )
+
+
+class TestMaterializedMarkerInteraction(TransactionCase):
+    """The _materialized marker flips _table_query's return value.
+
+    Regression fence for the C1 bug: without this behaviour, models that
+    inherit both ``sql.report.mixin`` and ``materialized.view.mixin`` have a
+    physical MV that the ORM never reads.
+    """
+
+    def _with_hooks(self, materialized):
+        """Return the _table_query value for a harness with given marker."""
+        mixin = self.env["sql.report.mixin"]
+        cls = type(mixin)
+        orig_select = cls._get_select_fields
+        orig_from = cls._get_from_tables
+        cls._get_select_fields = lambda self: {"id": "u.id"}
+        cls._get_from_tables = lambda self: [("res_users", "u", None, None)]
+        marker_patch = patch.object(cls, "_materialized", materialized, create=True)
+        try:
+            marker_patch.start()
+            return mixin._table_query
+        finally:
+            marker_patch.stop()
+            cls._get_select_fields = orig_select
+            cls._get_from_tables = orig_from
+
+    def test_non_materialized_returns_sql(self):
+        # The abstract mixin itself defines no fields, so we need to patch
+        # marker explicitly to False for this path.
+        tq = self._with_hooks(materialized=False)
+        self.assertIsInstance(tq, SQL)
+        self.assertTrue(bool(tq))
+
+    def test_materialized_returns_none(self):
+        tq = self._with_hooks(materialized=True)
+        self.assertIsNone(tq)

--- a/addons/base_vat/tests/test_vat_numbers.py
+++ b/addons/base_vat/tests/test_vat_numbers.py
@@ -1,13 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests.common import TransactionCase, tagged
-from odoo._monkeypatches.stdnum import new_get_soap_client
 from odoo.exceptions import ValidationError
 from unittest.mock import patch
 
 import stdnum.eu.vat
-from lxml import etree
-from zeep import Client, Transport
-from zeep.wsdl import Document
 
 
 class TestStructure(TransactionCase):
@@ -124,14 +120,6 @@ class TestStructure(TransactionCase):
         # Test invalid VAT (should raise a ValidationError)
         with self.assertRaises(ValidationError):
             test_partner.write({'vat': "136695978"})
-
-    def test_soap_client_for_vies_loads(self):
-        # Test of stdnum get_soap_client monkeypatch. This test is mostly to
-        # see that no unexpected import errors are thrown and not caught.
-        with patch.object(Document, '_get_xml_document', return_value=etree.Element("root")), \
-                patch.object(Client, 'service', return_value=None):
-            doc = Document(location=None, transport=Transport())
-            new_get_soap_client(doc, 30)
 
     def test_no_vies_revalidation_when_creating_company_from_contact(self):
         # Test that we don't revalidate the VAT when create a company from a contact where it's already validated

--- a/odoo/release.py
+++ b/odoo/release.py
@@ -32,6 +32,6 @@ author: Final[str] = "Odoo S.A."
 
 nt_service_name: str = "odoo-server-" + series.replace("~", "-")
 
-MIN_PY_VERSION: Final[tuple[int, int]] = (3, 13)
+MIN_PY_VERSION: Final[tuple[int, int]] = (3, 14)
 MAX_PY_VERSION: Final[tuple[int, int]] = (3, 14)
 MIN_PG_VERSION: Final[int] = 18


### PR DESCRIPTION
## Summary

Three small quality improvements bundled together. No single task ID — these are housekeeping changes.

### Commits

- **[IMP] base_sql_report: refactor mixins and add tests** — Simplify `sql_report_mixin` and `sql_materialized_mixin`, add test coverage for both, bump manifest to `19.0.2.0.0`.
- **[REM] base_vat: drop stale SOAP client monkeypatch test** — `test_soap_client_for_vies_loads` tested a stdnum monkeypatch no longer relevant; removes test and unused zeep/lxml imports.
- **[IMP] odoo: bump MIN_PY_VERSION to 3.14** — Align minimum with `MAX_PY_VERSION` since the fork already targets Python 3.14.

## Verification

- [ ] `./addons/core/odoo-bin -c ./conf/odoo.conf -d marin190 --test-tags '/base_sql_report' -u base_sql_report --stop-after-init --workers=0`
- [ ] `./addons/core/odoo-bin -c ./conf/odoo.conf -d marin190 --test-tags '/base_vat' -u base_vat --stop-after-init --workers=0`
- [ ] Odoo server starts successfully under Python 3.14