### PR TITLE
[CLA] mail, bus, gamification: drop upstream Odoo copyright header

### DIFF
--- a/addons/bus/controllers/home.py
+++ b/addons/bus/controllers/home.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import ipaddress
 
 from odoo import SUPERUSER_ID, _

--- a/addons/bus/controllers/main.py
+++ b/addons/bus/controllers/main.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from werkzeug.exceptions import BadRequest
 
 from odoo.http import Controller, request, route

--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.http import Controller, SessionExpiredException, request, route
 from odoo.libs.json import dumps as json_dumps
 

--- a/addons/bus/models/__init__.py
+++ b/addons/bus/models/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import bus
 from . import bus_listener_mixin
 from . import ir_attachment

--- a/addons/bus/models/bus_listener_mixin.py
+++ b/addons/bus/models/bus_listener_mixin.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/bus/models/ir_attachment.py
+++ b/addons/bus/models/ir_attachment.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/bus/models/ir_http.py
+++ b/addons/bus/models/ir_http.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, models
 from odoo.tools import config
 

--- a/addons/bus/models/ir_model.py
+++ b/addons/bus/models/ir_model.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 from odoo.http import SessionExpiredException, request
 from odoo.service import security

--- a/addons/bus/models/res_groups.py
+++ b/addons/bus/models/res_groups.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/bus/models/res_partner.py
+++ b/addons/bus/models/res_partner.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/bus/models/res_users.py
+++ b/addons/bus/models/res_users.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/bus/models/res_users_settings.py
+++ b/addons/bus/models/res_users_settings.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import contextlib
 import inspect
 import json

--- a/addons/bus/tests/test_assetsbundle.py
+++ b/addons/bus/tests/test_assetsbundle.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import odoo.tests
 
 

--- a/addons/bus/tests/test_bus_gc.py
+++ b/addons/bus/tests/test_bus_gc.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import datetime, timedelta
 from unittest.mock import patch
 

--- a/addons/bus/tests/test_health.py
+++ b/addons/bus/tests/test_health.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.tests import HttpCase
 
 

--- a/addons/bus/tests/test_ir_http.py
+++ b/addons/bus/tests/test_ir_http.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import MagicMock, patch
 
 from odoo.tests.common import BaseCase

--- a/addons/bus/tests/test_ir_model.py
+++ b/addons/bus/tests/test_ir_model.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import odoo
 from odoo.tests import HttpCase
 

--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import os
 import unittest
 from unittest.mock import MagicMock, patch

--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 import selectors
 import threading

--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import gc
 import json
 import os

--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.tests import JsonRpcException
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo

--- a/addons/bus/tests/test_websocket_rate_limiting.py
+++ b/addons/bus/tests/test_websocket_rate_limiting.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 import time
 

--- a/addons/gamification/models/gamification_activity.py
+++ b/addons/gamification/models/gamification_activity.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, fields, models
 
 

--- a/addons/gamification/models/gamification_mentorship.py
+++ b/addons/gamification/models/gamification_mentorship.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, exceptions, fields, models
 
 

--- a/addons/gamification/models/gamification_quest.py
+++ b/addons/gamification/models/gamification_quest.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, exceptions, fields, models
 
 

--- a/addons/gamification/models/gamification_season.py
+++ b/addons/gamification/models/gamification_season.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from typing import Any
 
 from odoo import _, api, fields, models

--- a/addons/gamification/models/gamification_skill.py
+++ b/addons/gamification/models/gamification_skill.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, fields, models
 
 

--- a/addons/gamification/tests/test_activity_feed.py
+++ b/addons/gamification/tests/test_activity_feed.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import patch
 
 from odoo.tests import common

--- a/addons/gamification/tests/test_engagement.py
+++ b/addons/gamification/tests/test_engagement.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import patch
 
 from odoo.tests import common

--- a/addons/gamification/tests/test_intelligence.py
+++ b/addons/gamification/tests/test_intelligence.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import patch
 
 from odoo import fields

--- a/addons/gamification/tests/test_mentorship.py
+++ b/addons/gamification/tests/test_mentorship.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import patch
 
 from odoo.exceptions import ValidationError

--- a/addons/gamification/tests/test_quest.py
+++ b/addons/gamification/tests/test_quest.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import patch
 
 from odoo.exceptions import UserError, ValidationError

--- a/addons/mail/__init__.py
+++ b/addons/mail/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import models
 from . import tools
 from . import wizard

--- a/addons/mail/controllers/__init__.py
+++ b/addons/mail/controllers/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import attachment
 from . import google_translate
 from . import guest

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import base64
 import io
 import logging

--- a/addons/mail/controllers/discuss/__init__.py
+++ b/addons/mail/controllers/discuss/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import channel
 from . import gif
 from . import public_page

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from markupsafe import Markup
 from werkzeug.exceptions import NotFound
 

--- a/addons/mail/controllers/discuss/gif.py
+++ b/addons/mail/controllers/discuss/gif.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 from urllib.parse import urlencode
 

--- a/addons/mail/controllers/discuss/public_page.py
+++ b/addons/mail/controllers/discuss/public_page.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import psycopg.errors
 from werkzeug.exceptions import NotFound
 

--- a/addons/mail/controllers/discuss/rtc.py
+++ b/addons/mail/controllers/discuss/rtc.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from collections import defaultdict
 
 from werkzeug.exceptions import NotFound

--- a/addons/mail/controllers/discuss/search.py
+++ b/addons/mail/controllers/discuss/search.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import http
 from odoo.fields import Domain
 from odoo.http import request

--- a/addons/mail/controllers/discuss/settings.py
+++ b/addons/mail/controllers/discuss/settings.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta

--- a/addons/mail/controllers/discuss/voice.py
+++ b/addons/mail/controllers/discuss/voice.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import http
 from odoo.http import request
 from odoo.tools import file_open

--- a/addons/mail/controllers/google_translate.py
+++ b/addons/mail/controllers/google_translate.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import babel
 import requests
 

--- a/addons/mail/controllers/guest.py
+++ b/addons/mail/controllers/guest.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from werkzeug.exceptions import NotFound
 
 from odoo import http

--- a/addons/mail/controllers/im_status.py
+++ b/addons/mail/controllers/im_status.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, http
 from odoo.http import request
 

--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import http
 from odoo.http import request
 

--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import http
 from odoo.http import request
 

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from werkzeug.exceptions import NotFound
 
 from odoo import http

--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import datetime
 
 from markupsafe import Markup

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from collections import defaultdict
 
 from odoo import http

--- a/addons/mail/controllers/webmanifest.py
+++ b/addons/mail/controllers/webmanifest.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.http import request
 from odoo.tools import file_open
 

--- a/addons/mail/controllers/websocket.py
+++ b/addons/mail/controllers/websocket.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.http import SessionExpiredException, request, route
 
 from odoo.addons.bus.controllers.websocket import WebsocketController

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 # core models (required for mixins)
 from . import mail_alias
 from . import mail_alias_domain

--- a/addons/mail/models/discuss/__init__.py
+++ b/addons/mail/models/discuss/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 # mail
 from . import mail_message
 

--- a/addons/mail/models/discuss/bus_listener_mixin.py
+++ b/addons/mail/models/discuss/bus_listener_mixin.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from markupsafe import Markup
 
 from odoo import models

--- a/addons/mail/models/discuss/discuss_call_history.py
+++ b/addons/mail/models/discuss/discuss_call_history.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models
 
 

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import base64
 from collections import defaultdict
 from datetime import timedelta

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 import uuid
 from datetime import timedelta

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 from collections import defaultdict
 

--- a/addons/mail/models/discuss/discuss_gif_favorite.py
+++ b/addons/mail/models/discuss/discuss_gif_favorite.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 
 

--- a/addons/mail/models/discuss/discuss_voice_metadata.py
+++ b/addons/mail/models/discuss/discuss_voice_metadata.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 
 

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 
 from odoo.addons.mail.tools.discuss import Store

--- a/addons/mail/models/discuss/ir_websocket.py
+++ b/addons/mail/models/discuss/ir_websocket.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import re
 
 from odoo import models

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import uuid
 from datetime import datetime, timedelta
 

--- a/addons/mail/models/discuss/mail_message.py
+++ b/addons/mail/models/discuss/mail_message.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models
 
 from odoo.addons.mail.tools.discuss import Store

--- a/addons/mail/models/discuss/res_groups.py
+++ b/addons/mail/models/discuss/res_groups.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models
 from odoo.exceptions import AccessError
 from odoo.fields import Domain

--- a/addons/mail/models/discuss/res_users.py
+++ b/addons/mail/models/discuss/res_users.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models
 
 from odoo.addons.mail.tools.discuss import Store

--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import datetime
 import functools
 import logging

--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import contextlib
 
 from odoo import _, api, fields, models

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, models
 
 

--- a/addons/mail/models/ir_cron.py
+++ b/addons/mail/models/ir_cron.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import SUPERUSER_ID, fields, models
 
 

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 from odoo.http import request
 

--- a/addons/mail/models/ir_mail_server.py
+++ b/addons/mail/models/ir_mail_server.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.fields import Domain

--- a/addons/mail/models/ir_model.py
+++ b/addons/mail/models/ir_model.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 

--- a/addons/mail/models/ir_model_fields.py
+++ b/addons/mail/models/ir_model_fields.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 from odoo.tools import groupby
 

--- a/addons/mail/models/ir_ui_menu.py
+++ b/addons/mail/models/ir_ui_menu.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import contextlib
 
 from odoo import api, models

--- a/addons/mail/models/ir_websocket.py
+++ b/addons/mail/models/ir_websocket.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 import re
 from collections import defaultdict

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 from ast import literal_eval
 from collections import Counter, defaultdict

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 from datetime import UTC, datetime
 

--- a/addons/mail/models/mail_activity_plan.py
+++ b/addons/mail/models/mail_activity_plan.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, fields, models
 
 

--- a/addons/mail/models/mail_activity_plan_template.py
+++ b/addons/mail/models/mail_activity_plan_template.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models

--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, exceptions, fields, models

--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import ast
 import contextlib
 import re

--- a/addons/mail/models/mail_alias_domain.py
+++ b/addons/mail/models/mail_alias_domain.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, exceptions, fields, models
 from odoo.exceptions import UserError
 

--- a/addons/mail/models/mail_alias_mixin.py
+++ b/addons/mail/models/mail_alias_mixin.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 
 from odoo import fields, models

--- a/addons/mail/models/mail_alias_mixin_optional.py
+++ b/addons/mail/models/mail_alias_mixin_optional.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 
 from odoo import api, fields, models

--- a/addons/mail/models/mail_blacklist.py
+++ b/addons/mail/models/mail_blacklist.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.fields import Domain

--- a/addons/mail/models/mail_canned_response.py
+++ b/addons/mail/models/mail_canned_response.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models
 
 from odoo.addons.mail.tools.discuss import Store

--- a/addons/mail/models/mail_composer_mixin.py
+++ b/addons/mail/models/mail_composer_mixin.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, fields, models, tools
 
 

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import itertools
 from collections import defaultdict
 

--- a/addons/mail/models/mail_gateway_allowed.py
+++ b/addons/mail/models/mail_gateway_allowed.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from markupsafe import Markup
 
 from odoo import _, api, fields, models, tools

--- a/addons/mail/models/mail_ice_server.py
+++ b/addons/mail/models/mail_ice_server.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 
 import requests

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import re
 from datetime import datetime
 from urllib.parse import urlparse

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import ast
 import contextlib
 import datetime

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import contextlib
 import logging
 import re

--- a/addons/mail/models/mail_message_link_preview.py
+++ b/addons/mail/models/mail_message_link_preview.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 
 from odoo.addons.mail.tools.discuss import Store

--- a/addons/mail/models/mail_message_reaction.py
+++ b/addons/mail/models/mail_message_reaction.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 from odoo.tools import groupby
 

--- a/addons/mail/models/mail_message_schedule.py
+++ b/addons/mail/models/mail_message_schedule.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 import logging
 from datetime import UTC, datetime

--- a/addons/mail/models/mail_message_subtype.py
+++ b/addons/mail/models/mail_message_subtype.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models, tools
 
 

--- a/addons/mail/models/mail_message_translation.py
+++ b/addons/mail/models/mail_message_translation.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models

--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import timedelta
 
 from odoo import api, fields, models, tools

--- a/addons/mail/models/mail_push.py
+++ b/addons/mail/models/mail_push.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 
 from requests import Session

--- a/addons/mail/models/mail_push_device.py
+++ b/addons/mail/models/mail_push_device.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 import logging as logger
 

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import copy
 import logging
 import re
@@ -662,9 +660,7 @@ class MailRenderMixin(models.AbstractModel):
             variables["object"] = record
 
             try:
-                results[record.id] = render_inline_template(
-                    parsed_template, variables
-                )
+                results[record.id] = render_inline_template(parsed_template, variables)
             except Exception as e:
                 _logger.info(
                     "Failed to render inline_template: \n%s",

--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 import logging
 from collections import defaultdict

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import base64
 import logging
 from ast import literal_eval

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import ast
 import base64
 import datetime

--- a/addons/mail/models/mail_thread_blacklist.py
+++ b/addons/mail/models/mail_thread_blacklist.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import AccessError, UserError
 from odoo.tools import SQL

--- a/addons/mail/models/mail_thread_cc.py
+++ b/addons/mail/models/mail_thread_cc.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models, tools
 
 

--- a/addons/mail/models/mail_thread_main_attachment.py
+++ b/addons/mail/models/mail_thread_main_attachment.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 
 from odoo.addons.mail.tools.discuss import Store

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from collections import defaultdict
 from datetime import datetime
 

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 from collections import defaultdict
 from datetime import datetime

--- a/addons/mail/models/res_company.py
+++ b/addons/mail/models/res_company.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models, tools
 
 

--- a/addons/mail/models/res_config_settings.py
+++ b/addons/mail/models/res_config_settings.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import datetime
 
 from odoo import _, fields, models

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import re
 
 from odoo import _, api, fields, models, tools

--- a/addons/mail/models/res_role.py
+++ b/addons/mail/models/res_role.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 
 

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import contextlib
 from collections import defaultdict
 
@@ -559,7 +557,9 @@ class ResUsers(models.Model):
 
         for activity in activities:
             if activity.res_model:
-                activities_rec_ids[activity.res_model][activity.res_id].append(activity.id)
+                activities_rec_ids[activity.res_model][activity.res_id].append(
+                    activity.id
+                )
             else:
                 activities_rec_ids["mail.activity"][activity.id].append(activity.id)
         # prefetch state for all activities to avoid per-record compute

--- a/addons/mail/models/res_users_settings.py
+++ b/addons/mail/models/res_users_settings.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models
 
 

--- a/addons/mail/models/res_users_settings_volumes.py
+++ b/addons/mail/models/res_users_settings_volumes.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models
 
 

--- a/addons/mail/models/template_reset_mixin.py
+++ b/addons/mail/models/template_reset_mixin.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 
 from lxml import etree

--- a/addons/mail/models/update.py
+++ b/addons/mail/models/update.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import contextlib
 import datetime
 import logging

--- a/addons/mail/static/scripts/odoo-mailgate.py
+++ b/addons/mail/static/scripts/odoo-mailgate.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 #
 # odoo-mailgate
 #

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import test_discuss_tools
 from . import test_fetchmail
 from . import test_font_to_img

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import base64
 import contextlib
 import email

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 
 from markupsafe import Markup

--- a/addons/mail/tests/discuss/__init__.py
+++ b/addons/mail/tests/discuss/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import test_avatar_acl
 from . import test_discuss_attachment_controller
 from . import test_discuss_binary_controller

--- a/addons/mail/tests/discuss/test_avatar_acl.py
+++ b/addons/mail/tests/discuss/test_avatar_acl.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import Command, fields
 from odoo.tests import HttpCase
 from odoo.tests.common import tagged

--- a/addons/mail/tests/discuss/test_discuss_action.py
+++ b/addons/mail/tests/discuss/test_discuss_action.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.tests import HttpCase, tagged
 
 from odoo.addons.mail.tests.common import MailCommon

--- a/addons/mail/tests/discuss/test_discuss_attachment_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_attachment_controller.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import odoo
 from odoo.tools.misc import file_open
 

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import base64
 import json
 from datetime import datetime, timedelta

--- a/addons/mail/tests/discuss/test_discuss_channel_access.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_access.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from psycopg.errors import UniqueViolation
 
 from odoo.exceptions import AccessError, UserError

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.tests.common import tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUserPortal

--- a/addons/mail/tests/discuss/test_discuss_channel_invite.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_invite.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 from itertools import product
 
 from lxml import html

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.exceptions import AccessError, ValidationError
 from odoo.tests.common import new_test_user, tagged
 

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 
 try:

--- a/addons/mail/tests/discuss/test_discuss_mention_suggestions.py
+++ b/addons/mail/tests/discuss/test_discuss_mention_suggestions.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import Command
 from odoo.tests.common import HttpCase, new_test_user, tagged
 

--- a/addons/mail/tests/discuss/test_discuss_sub_channels.py
+++ b/addons/mail/tests/discuss/test_discuss_sub_channels.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import datetime, timedelta
 from unittest.mock import patch
 

--- a/addons/mail/tests/discuss/test_guest_feature.py
+++ b/addons/mail/tests/discuss/test_guest_feature.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 
 from odoo.tests import tagged

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 
 import odoo

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import patch
 
 from dateutil.relativedelta import relativedelta

--- a/addons/mail/tests/discuss/test_toggle_upload.py
+++ b/addons/mail/tests/discuss/test_toggle_upload.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import Command, http
 from odoo.tests.common import HttpCase, tagged
 from odoo.tools import file_open

--- a/addons/mail/tests/discuss/test_ui.py
+++ b/addons/mail/tests/discuss/test_ui.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import odoo.tests
 from odoo import Command
 

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.tests import TransactionCase, tagged
 from odoo.tests.common import new_test_user
 

--- a/addons/mail/tests/test_fetchmail.py
+++ b/addons/mail/tests/test_fetchmail.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/addons/mail/tests/test_font_to_img.py
+++ b/addons/mail/tests/test_font_to_img.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from io import BytesIO
 
 from PIL import Image

--- a/addons/mail/tests/test_ir_mail_server.py
+++ b/addons/mail/tests/test_ir_mail_server.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 from contextlib import contextmanager
 from datetime import datetime, timedelta

--- a/addons/mail/tests/test_ir_ui_menu.py
+++ b/addons/mail/tests/test_ir_ui_menu.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import Mock, patch
 
 from odoo.tests import tagged, users

--- a/addons/mail/tests/test_ir_websocket.py
+++ b/addons/mail/tests/test_ir_websocket.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 from datetime import datetime, timedelta
 

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import io
 from unittest.mock import patch
 

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import re
 
 from odoo.exceptions import AccessError

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 # from odoo import exceptions
 from odoo.tests import new_test_user, tagged, users
 

--- a/addons/mail/tests/test_mail_message_translate.py
+++ b/addons/mail/tests/test_mail_message_translate.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 from http import HTTPStatus
 from unittest.mock import patch

--- a/addons/mail/tests/test_mail_presence.py
+++ b/addons/mail/tests/test_mail_presence.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import datetime, timedelta
 
 from freezegun import freeze_time

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from unittest.mock import patch
 
 from markupsafe import Markup

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 from unittest.mock import patch
 
 from markupsafe import Markup

--- a/addons/mail/tests/test_mail_tools.py
+++ b/addons/mail/tests/test_mail_tools.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.tests import tagged, users
 
 from odoo.addons.mail.tests.common import MailCommon

--- a/addons/mail/tests/test_res_partner.py
+++ b/addons/mail/tests/test_res_partner.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from contextlib import contextmanager
 from unittest.mock import patch
 from uuid import uuid4

--- a/addons/mail/tests/test_res_role.py
+++ b/addons/mail/tests/test_res_role.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import Command
 from odoo.tests.common import HttpCase, tagged
 

--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import datetime, timedelta
 from unittest import skip
 from unittest.mock import patch

--- a/addons/mail/tests/test_uninstall.py
+++ b/addons/mail/tests/test_uninstall.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.tests import TransactionCase, tagged
 
 

--- a/addons/mail/tests/test_websocket_controller.py
+++ b/addons/mail/tests/test_websocket_controller.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
 

--- a/addons/mail/tools/__init__.py
+++ b/addons/mail/tools/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import alias_error
 from . import discuss
 from . import link_preview

--- a/addons/mail/tools/alias_error.py
+++ b/addons/mail/tools/alias_error.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from dataclasses import dataclass, field
 
 

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import os
 from collections import defaultdict
 from datetime import date, datetime

--- a/addons/mail/tools/jwt.py
+++ b/addons/mail/tools/jwt.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import base64
 import binascii
 import enum

--- a/addons/mail/tools/link_preview.py
+++ b/addons/mail/tools/link_preview.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import re
 
 import chardet

--- a/addons/mail/tools/mail_validation.py
+++ b/addons/mail/tools/mail_validation.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 
 from odoo import tools

--- a/addons/mail/tools/parser.py
+++ b/addons/mail/tools/parser.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import ast
 
 from odoo.exceptions import ValidationError

--- a/addons/mail/tools/web_push.py
+++ b/addons/mail/tools/web_push.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import json
 import logging as logger
 import os

--- a/addons/mail/wizard/__init__.py
+++ b/addons/mail/wizard/__init__.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from . import base_module_uninstall
 from . import base_partner_merge_automatic_wizard
 from . import mail_blacklist_remove

--- a/addons/mail/wizard/base_module_uninstall.py
+++ b/addons/mail/wizard/base_module_uninstall.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import models
 
 

--- a/addons/mail/wizard/base_partner_merge_automatic_wizard.py
+++ b/addons/mail/wizard/base_partner_merge_automatic_wizard.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models
 
 

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import logging
 
 from markupsafe import Markup

--- a/addons/mail/wizard/mail_activity_schedule_summary.py
+++ b/addons/mail/wizard/mail_activity_schedule_summary.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import fields, models
 
 

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import ast
 import base64
 import datetime

--- a/addons/mail/wizard/mail_template_preview.py
+++ b/addons/mail/wizard/mail_template_preview.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 

--- a/addons/mail/wizard/mail_template_reset.py
+++ b/addons/mail/wizard/mail_template_reset.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import _, fields, models
 
 


### PR DESCRIPTION
## Summary

Remove the upstream Odoo per-file copyright header from Python files in `mail`, `bus`, and `gamification`. The fork's authoritative license source is the repository `LICENSE` file; the per-file comment adds no information and creates visual noise.

## Changes

- **183 files** — strip `# Part of Odoo. See LICENSE file for full copyright and licensing details.` from line 1
- **172 files** (subset of the above) — `ruff format` collapsed the blank line that previously followed the header
- No semantic code changes. Net diff: `4 insertions(+), 359 deletions(-)`
- `resource` module: 0 files had the header, not touched

### Per-module breakdown

| Module | Files touched |
|---|---|
| `mail` | 149 |
| `bus` | 24 |
| `gamification` | 10 |
| `resource` | 0 (already clean) |

## Verification

- [x] `ruff check addons/{mail,bus,gamification,resource}` → clean
- [x] `ruff format --check` → all formatted
- [ ] Smoke-test bootstrap: `odoo-bin -d <db> -i mail,bus,gamification --stop-after-init`