### PR TITLE
[IMP] gamification: best-in-class audit — cherry-pick from beb0311

### DIFF
--- a/addons/gamification/machine_doc_v1/architecture.md
+++ b/addons/gamification/machine_doc_v1/architecture.md
@@ -1,0 +1,471 @@
+# Gamification Architecture
+
+## Subsystem Overview
+
+The module has 8 interconnected subsystems:
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                           res.users (extended)                          │
+│  karma ◄── karma.tracking    rank_id ◄── karma.rank    badge_ids       │
+│  streak_ids   featured_badge_ids   xp_progress_percent   visibility    │
+└──┬───────────────┬─────────────────────────┬─────────────────────┬─────┘
+   │               │                         │                     │
+┌──▼──────┐  ┌─────▼─────┐  ┌───────────────▼──────┐  ┌──────────▼─────┐
+│CHALLENGE│  │RECOGNITION│  │    PROGRESSION        │  │   JOURNEYS     │
+│& GOALS  │  │           │  │                       │  │                │
+│         │  │ Badges    │  │ Karma    Skill Trees  │  │ Quests (steps) │
+│Challenge│─▶│ Kudos     │─▶│ Ranks    Skill Nodes  │  │ Seasons        │
+│Goal     │  │ Mentorship│  │ Streaks  Achievements │  │                │
+│GoalDef  │  │           │  │                       │  │                │
+└────┬────┘  └─────┬─────┘  └───────────┬───────────┘  └───────┬────────┘
+     │             │                    │                       │
+     └─────────────┴────────────────────┴───────────────────────┘
+                              │
+              ┌───────────────▼────────────────┐
+              │        SOCIAL & ANALYTICS      │
+              │                                │
+              │  Activity Feed (unified)       │
+              │  Engagement Snapshots (daily)  │
+              │  Leaderboards (karma/season)   │
+              │  Nudges (smart notifications)  │
+              │  Adaptive Difficulty           │
+              │  Teams                         │
+              └────────────────────────────────┘
+```
+
+### Subsystem Details
+
+**1. Challenges & Goals** — Manager-assigned objectives with periodic evaluation.
+The challenge orchestrates goal creation and lifecycle for groups of users.
+Supports adaptive difficulty based on user performance history.
+
+**2. Recognition** — Peer-to-peer and system-to-user reward mechanisms.
+Badges have complex granting rules. Kudos are lightweight, always-available.
+Mentorship pairs experienced users with newcomers for guided progression.
+
+**3. Progression** — XP-based advancement system.
+Karma is the universal currency. Ranks are thresholds. Streaks reward consistency.
+Achievements reward discovery. Skill trees provide branching progression paths.
+
+**4. Journeys** — Multi-step narrative experiences.
+Quests wrap goal definitions in ordered, prerequisite-linked steps with story.
+Seasons create time-limited events with exclusive rewards and fresh leaderboards.
+
+**5. Social & Analytics** — Visibility and measurement layer.
+Activity feed aggregates all gamification events into a single stream.
+Engagement snapshots capture daily metrics for trend analysis.
+Smart nudges detect disengagement patterns and send targeted notifications.
+Leaderboards respect privacy visibility settings.
+
+---
+
+## Karma Flow
+
+Karma is the central currency. It flows from multiple sources:
+
+```
+                    ┌─────────────┐
+Kudos ──────────────▶             │
+                    │   _add_karma │
+Streak daily ───────▶  _add_karma  │──▶ gamification.karma.tracking.create()
+                    │   _batch    │         │
+Achievement ────────▶             │         ▼
+                    └─────────────┘    res.users._compute_karma()
+                                           │
+Manual / write() ──────────────────────────┘
+                                           │
+                                           ▼
+                                    _recompute_rank()
+                                           │
+                                    ┌──────▼──────┐
+                                    │ rank_changed │
+                                    │ → badges     │
+                                    │ → bus notif  │
+                                    │ → email      │
+                                    └─────────────┘
+```
+
+**Key invariant:** `res.users.karma` is always computed from the latest
+`gamification.karma.tracking` record via `DISTINCT ON (user_id) ... ORDER BY user_id, tracking_date DESC, id DESC`.
+Direct writes to `karma` field trigger `_add_karma_batch` (via `res.users.write()`)
+which creates a tracking record, which then triggers `_compute_karma` via
+`@api.depends("karma_tracking_ids.new_value")`.
+
+**Caveat:** When karma is set via `write()`, the tracking record has no `source`
+or `reason` metadata — it defaults to the current user and `_("Add Manually")`.
+Always prefer `_add_karma(gain, source, reason)` for traceable karma changes.
+
+**Safety guard:** `_compute_karma` exits early when `skip_karma_computation=True`
+is in the context. This is critical during monthly consolidation — without it,
+deleting old tracking records would zero out user karma before the consolidated
+record triggers recomputation.
+
+---
+
+## Challenge Lifecycle
+
+```
+1. Manager creates challenge (draft)
+   ├── Defines line_ids (goal definitions + targets)
+   ├── Sets user_ids or user_domain
+   └── Sets reward badges (per-user, top-3)
+
+2. action_start() → write(state=inprogress)
+   ├── _recompute_challenge_users()  (add users from domain)
+   └── _generate_goals_from_challenge()
+       └── Creates one gamification.goal per user × line
+
+3. Daily cron: _cron_update() → _update_all()
+   ├── Add new users matching user_domain
+   ├── Generate missing goals
+   ├── goal.update_goal() for each goal (filtered by recent user presence):
+   │   ├── computation_mode=count → search_count(domain)
+   │   ├── computation_mode=sum → _read_group(domain, field:sum)
+   │   ├── computation_mode=python → safe_eval(compute_code)
+   │   └── computation_mode=manually → _check_remind_delay()
+   ├── State transitions (in goal._get_write_values):
+   │   ├── current >= target → state = reached
+   │   └── end_date passed → state = failed, closed = True
+   ├── reward_realtime: grant badge immediately on goal reached
+   ├── Send reports (if frequency matches)
+   └── Close expired periods, generate new goals for next period
+
+4. state = done
+   └── Grant ranking rewards (1st/2nd/3rd badges)
+```
+
+---
+
+## Streak Cron Pipeline
+
+**Cron:** `ir_cron_update_streaks` — runs daily at 06:00
+
+```
+_cron_update_streaks()
+    │
+    ├── if today.day == 1:
+    │       reset freeze_remaining for all active streaks
+    │
+    └── for each active streak where last_activity_date < today:
+            │
+            ├── streak_type._check_user_activity(user, yesterday)
+            │       │
+            │       ├── safe_eval(domain, {user, date_from, date_to})
+            │       └── search_count(domain + date filters, limit=1)
+            │
+            ├── if activity found:
+            │       streak._record_activity()
+            │           ├── current_count += 1
+            │           ├── longest_count = max(longest, current)
+            │           ├── user._add_karma(bonus * milestone_multiplier)
+            │           └── if milestone day: bus notification
+            │
+            ├── elif freeze_remaining > 0:
+            │       freeze_remaining -= 1
+            │
+            └── else:
+                    streak._break_streak()
+                        ├── current_count = 0
+                        └── state = broken
+```
+
+---
+
+## Achievement Cron Pipeline
+
+**Cron:** `ir_cron_check_achievements` — runs daily at 07:00
+
+```
+_cron_check_achievements()
+    │
+    └── for each active achievement:
+            _check_achievement_for_users(all_internal_users)
+                │
+                ├── Filter out already-unlocked users
+                │
+                └── for each candidate:
+                        safe_eval(trigger_domain, {user})
+                        if search_count(domain) >= trigger_count:
+                            create achievement.unlock
+                            _grant_rewards()
+                                ├── user._add_karma(karma_reward)
+                                ├── badge.user.create + _send_badge()
+                                └── bus notification
+```
+
+---
+
+## Karma Consolidation
+
+**Cron:** `ir_cron_consolidate` — runs monthly on 1st at 04:00
+
+Purpose: Compress old tracking records into one record per user per month.
+Processes records from the start of the month that is 2 calendar months
+before the current month (e.g., on March 26 it processes January records).
+
+```
+_consolidate_cron()
+    └── _process_consolidate(start_of_month - 2 months)
+            │
+            ├── SQL INSERT: one consolidated record per user/month
+            │   (oldest old_value + newest new_value)
+            │
+            └── ORM unlink() of original non-consolidated records
+                (with skip_karma_computation context to avoid
+                 triggering user.karma recomputation)
+```
+
+---
+
+## Bus Notifications
+
+All gamification events send real-time notifications via `bus.bus`:
+
+| Event | Channel | notif_type payload | Sender |
+|-------|---------|-------------------|--------|
+| Badge earned | user.partner_id | `badge` | `badge.user._send_badge()` |
+| Rank up | user.partner_id | `level_up` | `res.users._rank_changed()` |
+| Streak milestone | user.partner_id | `streak` | `streak._record_activity()` |
+| Achievement unlock | user.partner_id | `achievement` | `achievement.unlock._grant_rewards()` |
+
+All use channel type `"gamification/notification"` via bus._sendone.
+
+Most use `user._send_gamification_notification(type, data)` which calls
+`bus._sendone(user.partner_id, "gamification/notification", {type, ...data})`.
+
+**Exception:** Badge-earned notifications go through `gamification.badge.user._send_badge()`,
+which has its own bus notification logic separate from `_send_gamification_notification`.
+
+---
+
+## Security Model
+
+### Access Control (ir.model.access.csv)
+
+| Model | Employee (group_user) | Manager (group_erp_manager) | Portal | Public |
+|-------|----------------------|----------------------------|--------|--------|
+| goal | read, write | full CRUD | read, write | — |
+| goal.definition | read | full CRUD | read | — |
+| challenge | read | full CRUD | read | — |
+| challenge.line | read | full CRUD | read | — |
+| badge | read | full CRUD | read | read |
+| badge.user | read, write, create | full CRUD | read, write, create | read |
+| karma.rank | read | full CRUD (**group_system**) | read | read |
+| karma.tracking | none | full CRUD (**group_system**) | none | — |
+| streak.type | read | full CRUD | — | — |
+| streak | read, write | full CRUD | — | — |
+| kudos.category | read | full CRUD | — | — |
+| kudos | read, write, create | full CRUD | — | — |
+| achievement | read | full CRUD | — | — |
+| achievement.unlock | read | full CRUD | — | — |
+| team | read | full CRUD | — | — |
+| engagement.snapshot | read | full CRUD | — | — |
+| activity | read | full CRUD | — | — |
+| mentorship | read, write, create | full CRUD | — | — |
+| quest | read | full CRUD | — | — |
+| quest.step | read | full CRUD | — | — |
+| quest.enrollment | read, write, create | full CRUD | — | — |
+| quest.step.completion | read, write, create | full CRUD | — | — |
+| season | read | full CRUD | — | — |
+| skill.tree | read | full CRUD | — | — |
+| skill.node | read | full CRUD | — | — |
+| skill.node.unlock | read | full CRUD | — | — |
+
+### Row-Level Rules (ir.rule)
+
+| Rule XML ID | Model | Effect |
+|-------------|-------|--------|
+| `goal_user_visibility` | goal | Users see own goals + ranking-mode challenge goals |
+| `goal_gamification_manager_visibility` | goal | Managers see all goals |
+| `goal_global_multicompany` | goal | Filter by user's company |
+| `streak_user_write` | streak | Users can only modify own streaks |
+| `kudos_user_write` | kudos | Users can only modify own sent kudos |
+
+---
+
+## Dashboard Data Aggregation
+
+`res.users.get_gamification_dashboard_data()` is designed as a single RPC
+round-trip to populate the OWL dashboard component. It returns:
+
+```python
+{
+    "profile": {
+        "user_name", "karma", "rank_name", "rank_image",
+        "next_rank_name", "xp_progress_percent", "xp_to_next_rank",
+        "gold_badge", "silver_badge", "bronze_badge",
+        "featured_badges": [{"id", "badge_name", "badge_image", "level"}...],
+        "visibility",
+    },
+    "streaks": [{
+        "id", "name", "current_count", "longest_count",
+        "state", "freeze_remaining",
+    }...],
+    "goals": [{
+        "id", "challenge_name", "definition_name", "current",
+        "target", "completeness", "state", "end_date",
+    }...],
+    "badges": [{
+        "id", "badge_name", "badge_image", "level", "date", "sender_name",
+    }...],
+    "activity_feed": [{
+        "id", "activity_type", "user_name", "target_user_name",
+        "summary", "icon", "karma_gained", "date",
+    }...],
+    "achievements": [{
+        "id", "name", "description", "rarity", "date",
+    }...],
+    "leaderboard": [{
+        "user_id", "user_name", "karma", "rank_name", "is_current_user",
+    }...],
+}
+```
+
+### Additional RPC Methods
+
+| Method | Model | Purpose |
+|--------|-------|---------|
+| `get_activity_feed(limit=30)` | `gamification.activity` | Unified feed with privacy filtering |
+| `get_analytics_summary()` | `gamification.engagement.snapshot` | Latest metrics + 7-day trends |
+| `_get_karma_leaderboard(limit=10)` | `res.users` | Top karma users (privacy-filtered) |
+| `send_kudos_from_dashboard(recipient_id, category_id, message)` | `res.users` | Create kudos from dashboard inline form |
+| `get_season_leaderboard(limit=10)` | `gamification.season` | Karma earned during season window (**instance method**, requires specific record — not `@api.model`) |
+| `get_suggested_mentors(limit=5)` | `gamification.mentorship` | Higher-karma users available for mentoring |
+
+---
+
+## Quest Lifecycle
+
+```
+1. Admin creates quest with steps (ordered, prerequisite-linked)
+   ├── Each step references a goal.definition + target
+   ├── Steps can require prerequisite steps
+   └── Quest has completion badge + karma reward
+
+2. User enrolls → quest.enrollment (state=in_progress)
+
+3. User completes steps in order:
+   enrollment.complete_step(step)
+       ├── Validate prerequisites (all prereq steps completed)
+       ├── Create quest.step.completion record
+       ├── Grant step karma + badge rewards
+       └── Check if all steps done → auto-complete quest
+
+4. Quest auto-completes:
+   enrollment._complete_quest()
+       ├── state = completed
+       ├── Grant quest-level karma + badge
+       └── Log to activity feed
+```
+
+---
+
+## Skill Tree Unlock Flow
+
+```
+skill.node.unlock_for_user(user)
+    │
+    ├── check_unlock_for_user(user):
+    │       ├── Not already unlocked?
+    │       ├── All prerequisite nodes unlocked?
+    │       ├── Karma >= threshold?
+    │       └── Required quest completed?
+    │
+    ├── Create skill.node.unlock record
+    ├── Grant karma reward
+    ├── Grant badge reward
+    └── Log to activity feed
+```
+
+---
+
+## Season Lifecycle
+
+```
+draft ──→ active ──→ ended ──→ archived
+            │
+            ├── Challenges linked via season_id
+            ├── Exclusive badges via season_badge_rel
+            ├── Season leaderboard: karma earned between start/end dates
+            └── Fresh leaderboard solves "permanent bottom-half" problem
+```
+
+---
+
+## Engagement Nudge Pipeline
+
+**Cron:** `ir_cron_engagement_nudges` — runs daily at 09:00
+
+```
+_cron_engagement_nudges()
+    │
+    ├── _nudge_streak_warning()
+    │       Users with active streaks >= 3 days, 0 freeze remaining
+    │       → "Streak at Risk!" notification
+    │
+    ├── _nudge_close_to_rank()
+    │       Users within 10% of next rank's karma threshold
+    │       → "Almost There!" notification
+    │
+    ├── _nudge_goals_almost_done()
+    │       Goals >= 80% and < 100% complete, still in progress
+    │       → "So Close!" notification
+    │
+    └── _nudge_inactive_users()
+            Users who had karma activity 7-30 days ago but none in last 7 days
+            → "We Miss You!" notification
+```
+
+---
+
+## Adaptive Difficulty
+
+```
+challenge._compute_adaptive_targets()
+    │
+    ├── Only for recurring challenges (period != 'once')
+    │
+    └── For each user × line:
+            ├── Get last 3 closed goals
+            ├── Compute avg completion rate
+            ├── If avg > 90% → increase target by 15%
+            ├── If avg < 50% → decrease target by 15% (min 1)
+            └── Return {(user_id, line_id): adjusted_target}
+```
+
+---
+
+## Activity Feed Integration
+
+All gamification events auto-create `gamification.activity` records:
+
+| Source | Trigger Point | Activity Type |
+|--------|--------------|---------------|
+| `gamification.kudos` | `create()` | `kudos` |
+| `gamification.badge.user` | `_send_badge()` | `badge` |
+| `gamification.achievement.unlock` | `_grant_rewards()` | `achievement` |
+| `gamification.streak` | `_record_activity()` on milestones | `streak_milestone` |
+| `res.users` | `_rank_changed()` | `level_up` |
+| `gamification.quest.enrollment` | `_complete_quest()` | `challenge_completed` |
+| `gamification.skill.node` | `unlock_for_user()` | `achievement` |
+
+The feed respects `gamification_visibility` — activities from users with
+`visibility='private'` are excluded from `get_activity_feed()`.
+
+---
+
+## Privacy / Visibility Controls
+
+Users set `gamification_visibility` on their profile:
+
+| Setting | Leaderboard | Activity Feed | Dashboard Profile |
+|---------|-------------|---------------|-------------------|
+| `public` | Visible | Visible | Visible |
+| `team` | Visible | Visible | Visible |
+| `private` | **Hidden** | **Hidden** | Self only |
+
+Enforced in:
+- `res.users._get_karma_leaderboard()` — filters out private users
+- `gamification.activity.get_activity_feed()` — filters out private users' activities
+- `gamification.season.get_season_leaderboard()` — uses same SQL patterns

--- a/addons/gamification/machine_doc_v1/conventions.md
+++ b/addons/gamification/machine_doc_v1/conventions.md
@@ -1,0 +1,210 @@
+# Gamification Conventions & Gotchas
+
+## safe_eval Usage
+
+Four models use `safe_eval` to evaluate user-defined domains or code:
+
+| Model | Field | Variables Available |
+|-------|-------|--------------------|
+| `goal.definition` | `domain` | `user` (browse record of goal's user) |
+| `goal` | `definition.domain` (count/sum) | `user` (browse record of goal's user) |
+| `goal` | `definition.batch_user_expression` (batch) | `user` (browse record of goal's user) |
+| `goal` | `definition.compute_code` (python mode) | `object` (goal), `env`, `date`, `datetime`, `timedelta`, `time` |
+| `streak.type` | `domain` | `user`, `date_from`, `date_to` (string datetimes) |
+| `achievement` | `trigger_domain` | `user` (browse record) |
+
+**Security note:** `safe_eval` prevents arbitrary code execution but domains
+can still read any model's data. Goal definitions with `computation_mode=python`
+use `safe_eval(code, mode="exec")` which is more permissive — the `object`
+variable gives access to the goal record and `env` to the full ORM environment.
+Only admin users (`group_erp_manager`) can create goal definitions.
+
+---
+
+## Karma Tracking Invariants
+
+1. **Never write `karma` directly on `res.users` from Python** — always use
+   `user._add_karma(gain, source, reason)` or `_add_karma_batch()`.
+   Direct `user.karma = X` triggers `write()` which calls `_add_karma_batch`
+   internally, but loses the source/reason metadata.
+
+2. **`origin_ref` selection** must include all models that pass themselves as
+   `source` to `_add_karma`. Currently: `res.users`, `gamification.streak`,
+   `gamification.kudos`, `gamification.achievement.unlock`.
+   If a new module grants karma with a different source model, extend
+   `_get_origin_selection_values()`.
+
+3. **Consolidation context:** When deleting tracking records during
+   consolidation, use `with_context(skip_karma_computation=True)` to prevent
+   `_compute_karma` from running and zeroing out user karma.
+
+---
+
+## Naming Conventions
+
+| Pattern | Example | Rule |
+|---------|---------|------|
+| Model name | `gamification.streak.type` | Dot-separated, singular noun |
+| Field for user | `user_id` | Always `user_id`, never `partner_id` |
+| Computed count | `unlock_count`, `kudos_count` | `{thing}_count` |
+| Aggregate stat | `team_karma`, `team_badges` | `team_{metric}` |
+| Readonly computed | `readonly=True` (default) | Explicit `readonly=False` for editable |
+
+---
+
+## Cron Jobs
+
+| XML ID | Model | Schedule | Method |
+|--------|-------|----------|--------|
+| `ir_cron_check_challenge` | `gamification.challenge` | Daily | `_cron_update()` |
+| `ir_cron_update_streaks` | `gamification.streak` | Daily 06:00 | `_cron_update_streaks()` |
+| `ir_cron_check_achievements` | `gamification.achievement` | Daily 07:00 | `_cron_check_achievements()` |
+| `ir_cron_engagement_snapshot` | `gamification.engagement.snapshot` | Daily 08:00 | `_cron_record_snapshot()` |
+| `ir_cron_engagement_nudges` | `res.users` | Daily 09:00 | `_cron_engagement_nudges()` |
+| `ir_cron_consolidate` | `gamification.karma.tracking` | Monthly 1st 04:00 | `_consolidate_cron()` |
+
+**Execution order matters:**
+1. 06:00 — Streaks (may grant karma)
+2. 07:00 — Achievements (may check karma-dependent conditions)
+3. 08:00 — Engagement snapshot (captures fresh data after streaks/achievements)
+4. 09:00 — Nudges (detects patterns after all data is updated)
+5. Daily — Challenge check (goal evaluation + reports)
+
+---
+
+## Test Patterns
+
+### Base Classes
+
+- `TransactionCaseGamification` — sets demo user karma to 2500 **conditionally** (`if not self.user_demo.karma`); skips if karma already set
+- `HttpCaseGamification` — same, for HTTP tests
+
+### Test User Creation
+
+```python
+from odoo.addons.mail.tests.common import mail_new_test_user
+
+cls.user = mail_new_test_user(
+    cls.env,
+    login="test_login",
+    name="Test Name",
+    email="test@example.com",
+    karma=0,
+    groups="base.group_user",
+)
+```
+
+### Common Patterns
+
+1. **Patch send_mail** to avoid email sending:
+   ```python
+   patch_email = patch(
+       "odoo.addons.mail.models.mail_template.MailTemplate.send_mail",
+       lambda *args, **kwargs: None,
+   )
+   cls.startClassPatcher(patch_email)
+   ```
+
+2. **Override readonly fields** via SQL when needed (e.g., streak counts):
+   ```python
+   streak.env.cr.execute(
+       "UPDATE gamification_streak SET current_count = 6 WHERE id = %s",
+       [streak.id],
+   )
+   streak.invalidate_recordset()
+   ```
+
+3. **Date manipulation** with `freezegun`:
+   ```python
+   from freezegun import freeze_time
+
+   @freeze_time("2026-04-01")
+   def test_first_of_month(self):
+       ...
+   ```
+
+4. **Clean up before each test** when unique constraints exist:
+   ```python
+   def setUp(self):
+       super().setUp()
+       self.env["gamification.streak"].search([
+           ("user_id", "=", self.test_user.id),
+       ]).unlink()
+   ```
+
+### Running Tests
+
+```bash
+# All gamification tests
+> ./odoo.log && ./addons/core/odoo-bin -c ./odoo.conf -d test_db \
+    --test-tags '/gamification' -u gamification --stop-after-init --workers=0
+
+# Specific test class
+> ./odoo.log && ./addons/core/odoo-bin -c ./odoo.conf -d test_db \
+    --test-tags '/gamification:TestStreak' -u gamification --stop-after-init --workers=0
+
+# Check results
+grep "tests when loading" ./odoo.log
+```
+
+---
+
+## What NOT to Do
+
+1. **Don't create `gamification.badge.user` without checking granting rules.**
+   The `create()` method calls `check_granting()` which validates permissions.
+   Only `sudo()` bypasses this — used by challenge reward logic and achievement
+   unlock logic.
+
+2. **Don't call `_recompute_rank()` on large user sets unnecessarily.**
+   The method auto-switches to `_recompute_rank_bulk()` when the user count
+   exceeds `len(ranks) * 3`, but callers should still pre-filter to users
+   with `karma > 0 or rank_id`.
+
+3. **Don't assume `_ensure_user_streaks` has been called.**
+   Streak records are lazily created when `get_gamification_dashboard_data()`
+   is called. Code that queries streaks should handle missing records.
+
+4. **Don't use `f-strings` in `_add_karma` reason parameter for logging.**
+   The reason is stored in the database, not a log message. Use descriptive
+   text with `_()` for translation.
+
+5. **Don't create tracking records with `consolidated=True` manually.**
+   The consolidation cron handles this. Manual consolidated records will
+   confuse the consolidation logic.
+
+---
+
+## Extension Points
+
+Other modules can extend gamification by:
+
+1. **Creating `gamification.goal.definition` records** — define new measurable
+   objectives tied to any model (e.g., CRM leads, project tasks).
+
+2. **Extending `_get_origin_selection_values()`** — add new models as karma
+   sources if your module grants karma from a new origin.
+
+3. **Overriding `get_gamification_redirection_data()`** — add buttons to the
+   rank-reached email (e.g., "Go to Forum").
+
+4. **Creating `gamification.streak.type` records** — define new streak types
+   tied to any model's activity.
+
+5. **Creating `gamification.achievement` records** — define hidden achievements
+   with trigger domains on any model.
+
+6. **Creating `gamification.quest` records** — define multi-step narrative
+   journeys with ordered steps and prerequisites.
+
+7. **Creating `gamification.skill.tree` + `.node` records** — define branching
+   progression paths with karma thresholds and quest-linked unlocks.
+
+8. **Creating `gamification.season` records** — define time-limited themed
+   events with exclusive badges and seasonal leaderboards.
+
+9. **Using `gamification.activity._log_*` methods** — add custom events
+   to the unified social feed from other modules.
+
+10. **Adding nudge patterns** — extend `_cron_engagement_nudges()` to detect
+    module-specific disengagement patterns.

--- a/addons/gamification/machine_doc_v1/index.md
+++ b/addons/gamification/machine_doc_v1/index.md
@@ -1,0 +1,112 @@
+# Gamification Module — Machine Documentation v1
+
+## Purpose
+
+Best-in-class employee engagement platform: goals, badges, karma progression,
+peer recognition (kudos), streaks, hidden achievements, teams, multi-step
+quests, skill trees, seasonal events, mentorship, engagement analytics,
+adaptive difficulty, and smart nudges.
+
+## Module Metadata
+
+| Key | Value |
+|-----|-------|
+| Technical name | `gamification` |
+| Category | Human Resources |
+| Dependencies | `mail` |
+| Python models | 26 (across 19 files) + 2 wizards |
+| Views | 20 XML files |
+| Wizards | 2 transient models |
+| Cron jobs | 6 |
+| Test files | 13 (common + 12 test modules) |
+| Total tests | 145 |
+| OWL components | 2 (dashboard + notification service) |
+
+## File Inventory
+
+### Models (`models/`)
+
+| File | Models | Purpose |
+|------|--------|---------|
+| `gamification_challenge.py` | `gamification.challenge` | Challenge orchestration, adaptive difficulty |
+| `gamification_challenge_line.py` | `gamification.challenge.line` | Goal template within challenge |
+| `gamification_goal.py` | `gamification.goal` | Individual goal instance |
+| `gamification_goal_definition.py` | `gamification.goal.definition` | Goal computation template |
+| `gamification_badge.py` | `gamification.badge` | Badge with granting rules |
+| `gamification_badge_user.py` | `gamification.badge.user` | Badge grant instance |
+| `gamification_karma_rank.py` | `gamification.karma.rank` | XP rank thresholds |
+| `gamification_karma_tracking.py` | `gamification.karma.tracking` | Karma audit log |
+| `gamification_kudos.py` | `gamification.kudos.category`, `gamification.kudos` | Peer recognition |
+| `gamification_streak.py` | `gamification.streak.type`, `gamification.streak` | Daily activity streaks |
+| `gamification_achievement.py` | `gamification.achievement`, `gamification.achievement.unlock` | Hidden achievements |
+| `gamification_team.py` | `gamification.team` | Team competition |
+| `gamification_activity.py` | `gamification.activity` | Unified social activity feed |
+| `gamification_engagement.py` | `gamification.engagement.snapshot` | Daily engagement analytics |
+| `gamification_mentorship.py` | `gamification.mentorship` | Mentor/mentee pairing |
+| `gamification_quest.py` | `gamification.quest`, `.quest.step`, `.quest.enrollment`, `.quest.step.completion` | Multi-step narrative journeys |
+| `gamification_season.py` | `gamification.season` | Time-limited themed events |
+| `gamification_skill.py` | `gamification.skill.tree`, `.skill.node`, `.skill.node.unlock` | Branching skill progression |
+| `res_users.py` | extends `res.users` | Karma, ranks, profile, leaderboard, nudges |
+
+### Wizards (`wizard/`)
+
+| File | Model | Purpose |
+|------|-------|---------|
+| `update_goal.py` | `gamification.goal.wizard` | Manual goal value update |
+| `grant_badge.py` | `gamification.badge.user.wizard` | Grant badge to user |
+
+### Tests (`tests/`)
+
+| File | Classes | Coverage Area |
+|------|---------|---------------|
+| `common.py` | `HttpCaseGamification`, `TransactionCaseGamification` | Base setup (demo user with 2500 karma) |
+| `test_challenge.py` | `TestGamificationCommon`, `test_challenge`, `TestChallengeRewardNobodyBadge`, `test_badge_wizard` | Challenge lifecycle, goal generation, badge rewards |
+| `test_karma_tracking.py` | `TestKarmaTrackingCommon`, `TestComputeRankCommon` | Karma gain, consolidation, rank computation |
+| `test_kudos.py` | `TestKudos` | Kudos creation, karma grants, self-prevention |
+| `test_streak.py` | `TestStreakCommon`, `TestStreak` | Streak recording, freeze, break, milestones, cron |
+| `test_achievement.py` | `TestAchievement` | Trigger evaluation, unlock uniqueness, rewards |
+| `test_badge.py` | `TestBadgeGranting` | All 5 grant rules, monthly limits, stats |
+| `test_team.py` | `TestTeam` | Team stats, challenge scoring |
+| `test_engagement.py` | `TestEngagementSnapshot`, `TestDashboardEnhancements`, `TestProfileEnhancements` | Analytics snapshots, leaderboard, send-kudos, featured badges |
+| `test_activity_feed.py` | `TestActivityFeed` | Activity auto-creation from kudos/badges/achievements/level-ups |
+| `test_mentorship.py` | `TestMentorship` | Mentorship lifecycle, karma rewards, suggested mentors |
+| `test_quest.py` | `TestQuest`, `TestSeason`, `TestSkillTree` | Quest steps/prerequisites, season lifecycle, skill node unlocking |
+| `test_intelligence.py` | `TestAdaptiveDifficulty`, `TestEngagementNudges`, `TestVisibilityControls` | Adaptive targets, nudge patterns, privacy filtering |
+
+### Data (`data/`)
+
+| File | Content |
+|------|---------|
+| `gamification_badge_data.xml` | 4 default badges (Good Job, Problem Solver, Hidden, Brilliant) |
+| `gamification_challenge_data.xml` | 2 onboarding challenges: "Complete your Profile" + "Setup your Company" |
+| `gamification_karma_rank_data.xml` | 5 ranks (Newbie→Doctor) + root/admin karma |
+| `gamification_kudos_data.xml` | 5 categories (Teamwork, Innovation, Quality, Speed, Mentorship) |
+| `mail_template_data.xml` | 4 email templates: badge received, goal reminder, challenge report, new rank reached |
+| `ir_cron_data.xml` | 6 scheduled actions |
+
+### Static (`static/src/`)
+
+| File | Purpose |
+|------|---------|
+| `dashboard/gamification_dashboard.js` | OWL dashboard component (profile, leaderboard, feed, analytics) |
+| `dashboard/gamification_dashboard.xml` | Dashboard template with 8 sections |
+| `dashboard/gamification_dashboard.scss` | Dashboard styling |
+| `notifications/gamification_notification_service.js` | Real-time bus notification handler |
+| `scss/gamification.scss` | General gamification styles |
+
+## Reading Order
+
+1. **models.md** — All 28 models, fields, relationships, state machines
+2. **architecture.md** — Subsystem interactions, execution flows, cron pipeline
+3. **conventions.md** — Coding patterns, gotchas, safe_eval usage, test tags
+
+## Related Modules
+
+No enterprise or custom modules extend gamification in this codebase.
+Extension points for other modules:
+- Create `gamification.goal.definition` records for new measurable objectives
+- Create `gamification.streak.type` records for activity-based streaks
+- Create `gamification.achievement` records for hidden discovery achievements
+- Create `gamification.quest` records for guided onboarding journeys
+- Extend `_get_origin_selection_values()` to add new karma source models
+- Override `get_gamification_redirection_data()` for rank-reached email buttons

--- a/addons/gamification/machine_doc_v1/models.md
+++ b/addons/gamification/machine_doc_v1/models.md
@@ -1,0 +1,919 @@
+# Gamification Models
+
+## Model Relationship Diagram
+
+```
+gamification.challenge
+    ├── line_ids ──→ gamification.challenge.line
+    │                   └── definition_id ──→ gamification.goal.definition
+    ├── user_ids ──→ res.users (m2m)
+    ├── invited_user_ids ──→ res.users (m2m)
+    ├── team_ids ──→ gamification.team (m2m)
+    ├── report_message_group_id ──→ discuss.channel
+    ├── report_template_id ──→ mail.template
+    └── reward_id / reward_first_id / reward_second_id / reward_third_id ──→ gamification.badge
+
+gamification.goal
+    ├── definition_id ──→ gamification.goal.definition
+    ├── user_id ──→ res.users
+    ├── line_id ──→ gamification.challenge.line
+    └── challenge_id (related via line_id)
+
+gamification.badge
+    ├── owner_ids ──→ gamification.badge.user
+    │                   ├── user_id ──→ res.users
+    │                   └── badge_id ──→ gamification.badge
+    ├── challenge_ids ──→ gamification.challenge (o2m via reward_id)
+    └── goal_definition_ids ──→ gamification.goal.definition (m2m)
+
+gamification.karma.rank
+    └── user_ids ──→ res.users (rank_id)
+
+gamification.karma.tracking
+    └── user_id ──→ res.users
+
+gamification.kudos
+    ├── sender_id ──→ res.users
+    ├── recipient_id ──→ res.users
+    └── category_id ──→ gamification.kudos.category
+
+gamification.streak
+    ├── user_id ──→ res.users
+    └── streak_type_id ──→ gamification.streak.type
+
+gamification.achievement
+    └── unlock_ids ──→ gamification.achievement.unlock
+                        ├── user_id ──→ res.users
+                        └── achievement_id ──→ gamification.achievement
+
+gamification.team
+    ├── member_ids ──→ res.users (m2m)
+    ├── captain_id ──→ res.users
+    └── challenge_ids ──→ gamification.challenge (m2m)
+
+gamification.activity
+    ├── user_id ──→ res.users
+    ├── target_user_id ──→ res.users
+    ├── badge_id ──→ gamification.badge
+    ├── achievement_id ──→ gamification.achievement
+    └── challenge_id ──→ gamification.challenge
+
+gamification.engagement.snapshot
+    └── company_id ──→ res.company
+
+gamification.mentorship
+    ├── mentor_id ──→ res.users
+    ├── mentee_id ──→ res.users
+    └── completion_badge_id ──→ gamification.badge
+
+gamification.quest
+    ├── step_ids ──→ gamification.quest.step
+    │                   ├── definition_id ──→ gamification.goal.definition
+    │                   ├── prerequisite_ids ──→ gamification.quest.step (m2m)
+    │                   └── skill_node_id ──→ gamification.skill.node
+    ├── enrollment_ids ──→ gamification.quest.enrollment
+    │                       └── completion_ids ──→ gamification.quest.step.completion
+    ├── reward_badge_id ──→ gamification.badge
+    └── (via season) season_id on challenge ──→ gamification.season
+
+gamification.season
+    ├── challenge_ids ──→ gamification.challenge (o2m via season_id)
+    ├── badge_ids ──→ gamification.badge (m2m)
+    └── quest_ids ──→ gamification.quest (m2m)
+
+gamification.skill.tree
+    └── node_ids ──→ gamification.skill.node
+                        ├── prerequisite_ids ──→ gamification.skill.node (m2m)
+                        ├── quest_id ──→ gamification.quest
+                        ├── badge_id ──→ gamification.badge
+                        └── unlock_ids ──→ gamification.skill.node.unlock
+
+res.users (extended)
+    ├── karma (computed from karma_tracking_ids)
+    ├── rank_id ──→ gamification.karma.rank
+    ├── next_rank_id ──→ gamification.karma.rank
+    ├── badge_ids ──→ gamification.badge.user
+    ├── streak_ids ──→ gamification.streak
+    ├── featured_badge_ids ──→ gamification.badge.user (m2m)
+    └── gamification_visibility (selection: private/team/public)
+```
+
+---
+
+## 1. gamification.challenge
+
+**File:** `models/gamification_challenge.py`
+**Inherits:** `mail.thread`
+**Description:** Set of predefined objectives with recurrence rules and rewards.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Char | required, translate | Challenge name |
+| `description` | Text | translate | Long description |
+| `state` | Selection | `draft/inprogress/done`, tracking | Lifecycle state |
+| `manager_id` | Many2one `res.users` | default=uid | Responsible user |
+| `user_ids` | Many2many `res.users` | | Explicit participants |
+| `user_domain` | Char | | Alternative domain-based participants |
+| `user_count` | Integer | computed | # participants |
+| `period` | Selection | `once/daily/weekly/monthly/yearly`, required | Recurrence |
+| `start_date` | Date | | Period start |
+| `end_date` | Date | | Period end |
+| `line_ids` | One2many `challenge.line` | required, copy | Goal templates |
+| `reward_id` | Many2one `badge` | | Badge for every succeeder |
+| `reward_first_id` | Many2one `badge` | | Badge for 1st place |
+| `reward_second_id` | Many2one `badge` | | Badge for 2nd place |
+| `reward_third_id` | Many2one `badge` | | Badge for 3rd place |
+| `reward_failure` | Boolean | | Reward bests even if not succeeded |
+| `reward_realtime` | Boolean | default=True | Grant badge immediately on goal completion |
+| `visibility_mode` | Selection | `personal/ranking`, required | Individual or leaderboard |
+| `challenge_mode` | Selection | `individual/team`, required | Competition mode |
+| `team_ids` | Many2many `team` | | Competing teams |
+| `invited_user_ids` | Many2many `res.users` | | Suggested challenge participants |
+| `report_message_frequency` | Selection | `never/onchange/daily/weekly/monthly/yearly`, required | Report frequency |
+| `report_message_group_id` | Many2one `discuss.channel` | | Channel for report copies |
+| `report_template_id` | Many2one `mail.template` | required | Email template for reports |
+| `remind_update_delay` | Integer | | Days before reminder for manual goals |
+| `last_report_date` | Date | default=today | Last report sent |
+| `next_report_date` | Date | computed, stored | Next scheduled report |
+| `challenge_category` | Selection | `hr/other`, required | Menu visibility |
+
+### State Machine
+
+```
+draft ──→ inprogress ──→ done
+```
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `action_start()` | Transition draft → inprogress, generate goals |
+| `action_check()` | Update goals and generate reports |
+| `action_report_progress()` | Send progress report to participants |
+| `_update_all()` | Full cycle: add users from domain, generate goals, update, close expired |
+| `_cron_update()` | Entry point for daily cron |
+| `_generate_goals_from_challenge()` | Create goal records for each user × line |
+| `report_progress()` | Generate and send challenge report emails |
+| `accept_challenge()` | User accepts a suggested challenge |
+| `discard_challenge()` | User discards a suggested challenge |
+| `_check_challenge_reward()` | Grant badges for challenge completion/ranking |
+| `_recompute_challenge_users()` | Refresh user list from user_domain |
+| `start_end_date_for_period()` | Module-level helper returning (start, end) dates |
+
+---
+
+## 2. gamification.challenge.line
+
+**File:** `models/gamification_challenge_line.py`
+**Description:** Goal template within a challenge — one line generates one goal per participant.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `challenge_id` | Many2one `challenge` | required, ondelete=cascade | Parent challenge |
+| `definition_id` | Many2one `goal.definition` | required | What to measure |
+| `target_goal` | Float | required | Target value |
+| `sequence` | Integer | | Ordering |
+| `name` | Char | related to definition | Display name |
+| `condition` | Selection | related to definition | higher/lower |
+
+---
+
+## 3. gamification.goal
+
+**File:** `models/gamification_goal.py`
+**Inherits:** `mail.thread`
+**Description:** Individual goal instance for a user in a specific time period.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `definition_id` | Many2one `goal.definition` | required, ondelete=cascade | What to measure |
+| `user_id` | Many2one `res.users` | required, indexed, ondelete=cascade | Participant |
+| `line_id` | Many2one `challenge.line` | ondelete=cascade | Source template |
+| `challenge_id` | Many2one | related via line_id, stored, indexed | Parent challenge |
+| `start_date` | Date | default=today | Period start |
+| `end_date` | Date | | Period end |
+| `target_goal` | Float | required | Target value |
+| `current` | Float | required, default=0 | Current value |
+| `completeness` | Float | computed | 0-100% completion |
+| `state` | Selection | `draft/inprogress/reached/failed/canceled` | Goal state |
+| `to_update` | Boolean | | Needs manual update |
+| `closed` | Boolean | | Goal finalized |
+| `color` | Integer | computed | 0/2(failed late)/5(reached late) |
+
+### State Machine
+
+```
+draft ──→ inprogress ──→ reached
+                    └──→ failed (closed=True)
+Note: "canceled" exists as a state value but no method transitions to it;
+action_cancel() resets state back to inprogress.
+```
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `update_goal()` | Recompute value based on computation_mode (manually/count/sum/python) |
+| `_get_write_values(new_value)` | Compare value to target, determine state transition |
+| `_check_remind_delay()` | Send reminder email for stale manual goals |
+| `get_action()` | Return action dict to update goal (wizard or linked action) |
+| `action_start()` | Transition draft → inprogress, call update_goal() |
+| `action_reach()` | Mark goal as reached |
+| `action_fail()` | Mark goal as failed |
+| `action_cancel()` | Reset reached/failed back to inprogress |
+
+---
+
+## 4. gamification.goal.definition
+
+**File:** `models/gamification_goal_definition.py`
+**Description:** Template defining how a goal is evaluated.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Char | required, translate | Goal name |
+| `computation_mode` | Selection | `manually/count/sum/python`, required | How to compute |
+| `display_mode` | Selection | `progress/boolean` | Numeric or done/not-done |
+| `model_id` | Many2one `ir.model` | | Target model (for count/sum) |
+| `field_id` | Many2one `ir.model.fields` | | Field to sum |
+| `field_date_id` | Many2one `ir.model.fields` | | Date field for period filter |
+| `domain` | Char | required, default=`[]` | ORM domain (may reference `user`) |
+| `batch_mode` | Boolean | | Evaluate in batch vs per-user |
+| `batch_distinctive_field` | Many2one `ir.model.fields` | | Field distinguishing users in batch |
+| `batch_user_expression` | Char | | Expression to identify user in batch |
+| `compute_code` | Text | | Python code for `python` mode |
+| `condition` | Selection | `higher/lower`, required | Goal direction |
+| `monetary` | Boolean | | Values in company currency |
+| `suffix` | Char | translate | Unit label (e.g., "leads") |
+| `full_suffix` | Char | computed | Currency symbol + suffix combined |
+| `action_id` | Many2one `ir.actions.act_window` | | Linked action for manual update |
+| `res_id_field` | Char | | Field on res.users for action context |
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_compute_full_suffix()` | Combine currency symbol + suffix |
+| `_check_domain_validity()` | Validate domain syntax via test search_count |
+| `_check_model_validity()` | Verify field exists and is stored |
+| `create()` | Validates domain and model on creation |
+| `write()` | Re-validates domain/model when relevant fields change |
+
+---
+
+## 5. gamification.badge
+
+**File:** `models/gamification_badge.py`
+**Inherits:** `mail.thread`, `image.mixin`
+**Description:** Achievement award that users can send and receive.
+
+### Grant Status Constants
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `CAN_GRANT` | 1 | User is allowed |
+| `NOBODY_CAN_GRANT` | 2 | Badge rule_auth = nobody |
+| `USER_NOT_VIP` | 3 | User not in authorized list |
+| `BADGE_REQUIRED` | 4 | User lacks prerequisite badges |
+| `TOO_MANY` | 5 | Monthly limit exceeded |
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Char | required, translate | Badge name |
+| `level` | Selection | `bronze/silver/gold` | Forum badge level |
+| `rule_auth` | Selection | `everyone/users/having/nobody`, required | Who can grant |
+| `rule_auth_user_ids` | Many2many `res.users` | | Authorized givers (rule_auth=users) |
+| `rule_auth_badge_ids` | Many2many `badge` | | Required badges (rule_auth=having) |
+| `rule_max` | Boolean | | Monthly limit enabled |
+| `rule_max_number` | Integer | | Max grants per person per month |
+| `granted_count` | Integer | computed (SQL) | Total grants |
+| `granted_users_count` | Integer | computed (SQL) | Unique recipients |
+| `stat_this_month` | Integer | computed (SQL) | Monthly grants |
+| `stat_my_monthly_sending` | Integer | computed (SQL) | Current user's monthly sends |
+| `remaining_sending` | Integer | computed | Grants remaining (-1 = unlimited) |
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_can_grant_badge()` | Return status code (1-5) |
+| `check_granting()` | Raise UserError if user cannot grant |
+| `_get_owners_info()` | SQL aggregation for owner stats |
+| `_get_badge_user_stats()` | SQL FILTER aggregation for per-user/monthly stats |
+| `_remaining_sending_calc()` | Compute remaining grants |
+
+---
+
+## 6. gamification.badge.user
+
+**File:** `models/gamification_badge_user.py`
+**Inherits:** `mail.thread`
+**Description:** Instance of a badge granted to a user.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `user_id` | Many2one `res.users` | required, indexed, ondelete=cascade | Recipient |
+| `sender_id` | Many2one `res.users` | | Who granted |
+| `badge_id` | Many2one `badge` | required, indexed, ondelete=cascade | Which badge |
+| `challenge_id` | Many2one `challenge` | | Challenge that triggered |
+| `comment` | Text | | Grant comment |
+| `level` | Selection | related to badge.level, stored | Denormalized level |
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_send_badge()` | Send notification email + bus notification |
+| `create()` | Validates badge granting rights via `check_granting()` |
+
+---
+
+## 7. gamification.karma.rank
+
+**File:** `models/gamification_karma_rank.py`
+**Inherits:** `image.mixin`
+**Description:** Level thresholds in the karma progression system.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Text | required, translate | Rank name (e.g., "Master") |
+| `description` | Html | translate | Shown on profile |
+| `description_motivational` | Html | translate | Motivational text |
+| `description_perks` | Html | translate | Unlocked perks |
+| `karma_min` | Integer | required, default=1, CHECK > 0 | XP threshold |
+| `level_number` | Integer | default=0 | Sequential level display |
+| `unlock_badge_ids` | Many2many `badge` | | Auto-granted on rank-up |
+| `user_ids` | One2many `res.users` | | Users at this rank |
+| `rank_users_count` | Integer | computed | Count |
+
+### Default Ranks (data)
+
+| Rank | karma_min |
+|------|-----------|
+| Newbie | 1 |
+| Student | 100 |
+| Bachelor | 500 |
+| Master | 2000 |
+| Doctor | 10000 |
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `create()` | Triggers rank recomputation for affected users |
+| `write()` | Reranks users when karma_min changes |
+
+---
+
+## 8. gamification.karma.tracking
+
+**File:** `models/gamification_karma_tracking.py`
+**Description:** Audit log of karma changes. Source of truth for user karma.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `user_id` | Many2one `res.users` | required, indexed, ondelete=cascade | User |
+| `old_value` | Integer | readonly | Karma before |
+| `new_value` | Integer | required | Karma after |
+| `gain` | Integer | computed (new - old) | Delta |
+| `consolidated` | Boolean | | Part of monthly rollup |
+| `tracking_date` | Datetime | default=now, indexed | When |
+| `reason` | Text | default="Add Manually" | Human description |
+| `origin_ref` | Reference | `res.users`, `gamification.streak`, `gamification.kudos`, `gamification.achievement.unlock` | Source record |
+| `origin_ref_model_name` | Selection | computed, stored | Model type of origin |
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `create()` | Auto-fills old_value from current user karma |
+| `_consolidate_cron()` | Monthly cron: merge old trackings into single records |
+| `_process_consolidate(from_date, end_date=None)` | SQL INSERT + ORM unlink for monthly consolidation |
+
+---
+
+## 9. gamification.kudos + gamification.kudos.category
+
+**File:** `models/gamification_kudos.py`
+
+### gamification.kudos.category
+
+**Description:** Category for peer recognition (e.g., Teamwork, Innovation).
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `name` | Char | Category name |
+| `icon` | Char | Font Awesome class |
+| `karma_granted` | Integer | Karma auto-granted to recipient |
+| `kudos_count` | Integer | Computed count |
+
+### gamification.kudos
+
+**Inherits:** `mail.thread`
+**Description:** Peer-to-peer recognition message.
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `sender_id` | Many2one `res.users` | required, readonly, default=uid, ondelete=cascade | Sender |
+| `recipient_id` | Many2one `res.users` | required, ondelete=cascade | Recipient |
+| `category_id` | Many2one `kudos.category` | required, ondelete=restrict | Category |
+| `message` | Text | required | Recognition message |
+| `summary` | Char | computed, stored | Auto-generated one-liner |
+| `karma_granted` | Integer | readonly | Karma actually granted |
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `create()` | Validates no self-kudos, grants karma, posts to mail thread |
+
+### Default Categories (data)
+
+| Category | karma_granted | Icon |
+|----------|---------------|------|
+| Teamwork | 5 | `fa fa-users` |
+| Innovation | 10 | `fa fa-lightbulb-o` |
+| Quality | 5 | `fa fa-diamond` |
+| Speed | 5 | `fa fa-bolt` |
+| Mentorship | 10 | `fa fa-graduation-cap` |
+
+---
+
+## 10. gamification.streak.type + gamification.streak
+
+**File:** `models/gamification_streak.py`
+
+### gamification.streak.type
+
+**Description:** Configurable streak type — defines what activity sustains the streak.
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Char | required, translate | Streak name |
+| `model_id` | Many2one `ir.model` | required, ondelete=cascade | Target model |
+| `domain` | Char | required, default=`[]` | Activity domain (refs: `user`, `date_from`, `date_to`) |
+| `date_field_id` | Many2one `ir.model.fields` | required, ondelete=cascade | Date field to check |
+| `karma_bonus` | Integer | default=0 | Daily karma bonus |
+| `freeze_allowance` | Integer | default=2 | Skip days per month |
+
+### STREAK_MILESTONES (module constant)
+
+| Day | Karma Multiplier |
+|-----|-----------------|
+| 7 | 2x |
+| 30 | 5x |
+| 100 | 10x |
+| 365 | 25x |
+
+### gamification.streak
+
+**Description:** Per-user streak instance tracking consecutive daily activity.
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `user_id` | Many2one `res.users` | required, indexed, ondelete=cascade | User |
+| `streak_type_id` | Many2one `streak.type` | required, indexed, ondelete=cascade | Type |
+| `current_count` | Integer | readonly | Current consecutive days |
+| `longest_count` | Integer | readonly | All-time best |
+| `last_activity_date` | Date | readonly | Last recorded day |
+| `freeze_remaining` | Integer | | Freeze days left this month |
+| `state` | Selection | `active/broken`, readonly, indexed | Current state |
+| `total_karma_earned` | Integer | readonly | Cumulative karma from streak |
+
+**Unique constraint:** `(user_id, streak_type_id)` — one streak per type per user.
+
+### State Machine
+
+```
+active ←──→ broken
+  (via _record_activity revives broken streaks)
+```
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_record_activity()` | Increment count, grant karma (with milestone multiplier) |
+| `_break_streak()` | Reset current_count=0, state=broken, preserve longest |
+| `_cron_update_streaks()` | Daily: check activity, use freeze or break, reset freeze on 1st |
+| `_ensure_user_streaks(user)` | Create missing streak records for all active types |
+
+### gamification.streak.type Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_check_user_activity(user, check_date)` | Evaluate domain for given date, return True if match |
+| `_compute_user_count()` | Count active streaks per type |
+
+---
+
+## 11. gamification.achievement + gamification.achievement.unlock
+
+**File:** `models/gamification_achievement.py`
+
+### gamification.achievement
+
+**Description:** Hidden/discovery achievement unlocked through normal work.
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Char | required, translate | Achievement name |
+| `description` | Text | translate | Shown after unlock |
+| `hint` | Text | translate | Shown before unlock |
+| `model_id` | Many2one `ir.model` | required, ondelete=cascade | Trigger model |
+| `trigger_domain` | Char | required, default=`[]` | Domain (refs: `user`) |
+| `trigger_count` | Integer | default=1 | Records needed to unlock |
+| `badge_id` | Many2one `badge` | | Reward badge |
+| `karma_reward` | Integer | default=0 | Reward karma |
+| `rarity` | Selection | `common/rare/epic/legendary` | Rarity tier |
+| `hidden` | Boolean | default=True | Mystery (name hidden until unlock) |
+| `unlock_count` | Integer | computed | # users who unlocked |
+
+### gamification.achievement.unlock
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `achievement_id` | Many2one | required, indexed, ondelete=cascade | Achievement |
+| `user_id` | Many2one | required, indexed, ondelete=cascade | User |
+| `unlock_date` | Datetime | readonly, default=now | When unlocked |
+| `rarity` | Selection | related, stored | Denormalized |
+
+**Unique constraint:** `(user_id, achievement_id)` — one unlock per user per achievement.
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_check_achievement_for_users(users)` | Evaluate trigger domain, create unlocks |
+| `_cron_check_achievements()` | Daily: check all active achievements for all users |
+| `_grant_rewards()` | (on unlock) Grant karma + badge + bus notification |
+
+---
+
+## 12. gamification.team
+
+**File:** `models/gamification_team.py`
+**Inherits:** `mail.thread`
+**Description:** Team for collaborative challenges.
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Char | required, translate, tracking | Team name |
+| `member_ids` | Many2many `res.users` | | Members |
+| `captain_id` | Many2one `res.users` | | Team leader |
+| `member_count` | Integer | computed | # members |
+| `team_karma` | Integer | computed, stored | Sum of members' karma |
+| `team_badges` | Integer | computed, stored | Total badges |
+| `challenge_ids` | Many2many `challenge` | | Active challenges |
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `get_team_challenge_score(challenge)` | Average completeness of members' goals |
+
+---
+
+## 13. res.users (extension)
+
+**File:** `models/res_users.py`
+**Description:** Extends base user model with gamification fields and methods.
+
+### Added Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `karma` | Integer | computed (from tracking), stored, readonly=False | XP points |
+| `karma_tracking_ids` | One2many `karma.tracking` | groups=system | Audit log |
+| `badge_ids` | One2many `badge.user` | | Earned badges |
+| `gold_badge` | Integer | computed (SQL) | Count |
+| `silver_badge` | Integer | computed (SQL) | Count |
+| `bronze_badge` | Integer | computed (SQL) | Count |
+| `rank_id` | Many2one `karma.rank` | indexed | Current rank |
+| `next_rank_id` | Many2one `karma.rank` | | Next rank |
+| `xp_to_next_rank` | Integer | computed | XP remaining |
+| `xp_progress_percent` | Float | computed | 0-100% progress |
+| `streak_ids` | One2many `streak` | | User's streaks |
+
+### Key Methods
+
+| Method | Trigger | Purpose |
+|--------|---------|---------|
+| `_compute_karma()` | `karma_tracking_ids.new_value` | SQL DISTINCT ON latest tracking per user |
+| `_get_user_badge_level()` | `badge_ids` | SQL GROUP BY for gold/silver/bronze counts |
+| `_compute_xp_progress()` | `karma, rank_id, next_rank_id` | Progress bar calculation |
+| `_add_karma(gain, source, reason)` | explicit call | Create tracking record (single user) |
+| `_add_karma_batch(values_per_user)` | explicit call | Create tracking records (batch) |
+| `_recompute_rank()` | after karma change | Match user to rank tier |
+| `_recompute_rank_bulk()` | >N users | Optimized batch rank assignment |
+| `_rank_changed()` | after rank change | Grant unlock badges + send notification |
+| `_send_gamification_notification()` | various | Bus notification to user's partner |
+| `get_gamification_dashboard_data()` | @api.model RPC | Aggregate all gamification data for dashboard |
+| `_get_next_rank()` | explicit call | Return next karma rank for this user |
+| `get_gamification_redirection_data()` | extension hook | Add redirect buttons to rank-reached email |
+| `action_karma_report()` | UI action | Open karma tracking list for this user |
+| `_get_tracking_karma_gain_position()` | explicit call | Ranked karma gain in date range (SQL) |
+| `_get_karma_position()` | explicit call | Absolute total-karma rank position (SQL) |
+| `create()` | | Track initial karma via _add_karma_batch |
+| `write()` | `karma` in vals | Track karma changes via _add_karma_batch |
+| `_get_karma_leaderboard(limit=10)` | @api.model | Top karma users (privacy-filtered) |
+| `send_kudos_from_dashboard(recipient_id, category_id, message)` | @api.model | Create kudos inline from dashboard |
+| `_cron_engagement_nudges()` | @api.model cron | Detect patterns, send targeted notifications |
+| `_nudge_streak_warning()` | internal | Warn users with 0 freeze days left |
+| `_nudge_close_to_rank()` | internal | Notify users within 10% of next rank |
+| `_nudge_goals_almost_done()` | internal | Notify users with >80% complete goals |
+| `_nudge_inactive_users()` | internal | Re-engage users inactive for 7+ days |
+
+---
+
+## 14. gamification.activity
+
+**File:** `models/gamification_activity.py`
+**Inherits:** `mail.thread`
+**Description:** Unified social feed for all gamification events.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `activity_type` | Selection | `badge/kudos/achievement/streak_milestone/level_up/challenge_completed`, required, indexed | Event type |
+| `user_id` | Many2one `res.users` | required, indexed, ondelete=cascade | Who did/received |
+| `target_user_id` | Many2one `res.users` | indexed, ondelete=set null | Secondary user (e.g. kudos recipient) |
+| `company_id` | Many2one `res.company` | related to user, stored, indexed | Company filter |
+| `summary` | Char | required | Human-readable one-liner |
+| `icon` | Char | | Font Awesome CSS class |
+| `activity_date` | Datetime | default=now, indexed | When |
+| `badge_id` | Many2one `badge` | ondelete=set null | Source badge (if applicable) |
+| `achievement_id` | Many2one `achievement` | ondelete=set null | Source achievement |
+| `challenge_id` | Many2one `challenge` | ondelete=set null | Source challenge |
+| `karma_gained` | Integer | | Karma earned in this event |
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_log_badge(user, badge, sender)` | Record badge-earned activity |
+| `_log_kudos(sender, recipient, category, karma)` | Record kudos-sent activity |
+| `_log_achievement(user, achievement, karma)` | Record achievement-unlocked activity |
+| `_log_streak_milestone(user, streak_type, day_count, karma)` | Record streak milestone |
+| `_log_level_up(user, rank)` | Record level-up activity |
+| `_log_challenge_completed(user, challenge)` | Record challenge completion |
+| `get_activity_feed(limit=30)` | Return formatted feed (privacy-filtered) |
+
+---
+
+## 15. gamification.engagement.snapshot
+
+**File:** `models/gamification_engagement.py`
+**Description:** Daily snapshot of gamification engagement metrics.
+
+### Fields (25+ metrics across 6 categories)
+
+| Category | Fields |
+|----------|--------|
+| Users | `total_users`, `users_with_karma`, `active_users_7d`, `active_users_30d` |
+| Goals | `active_challenges`, `goals_in_progress`, `goals_reached_7d`, `goal_completion_rate` |
+| Badges | `total_badges_granted`, `badges_granted_7d`, `unique_badge_holders` |
+| Kudos | `total_kudos`, `kudos_7d`, `unique_kudos_senders_7d`, `unique_kudos_recipients_7d` |
+| Streaks | `active_streaks`, `broken_streaks`, `avg_streak_length`, `streaks_past_7d`, `streaks_past_30d` |
+| Karma | `total_karma_granted`, `karma_granted_7d`, `avg_user_karma` |
+
+**Unique:** `(snapshot_date, company_id)` — one per company per day.
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_cron_record_snapshot()` | Daily cron: record snapshot for each company |
+| `_record_snapshot(company)` | Compute and store metrics (idempotent) |
+| `get_analytics_summary()` | Return latest + 7-day trend comparison |
+
+---
+
+## 16. gamification.mentorship
+
+**File:** `models/gamification_mentorship.py`
+**Inherits:** `mail.thread`
+**Description:** Mentor/mentee pairing with karma incentives.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `mentor_id` | Many2one `res.users` | required, indexed, tracking | Mentor |
+| `mentee_id` | Many2one `res.users` | required, indexed, tracking | Mentee |
+| `state` | Selection | `active/completed/cancelled`, tracking, indexed | Lifecycle |
+| `start_date` | Date | default=today, readonly | When started |
+| `end_date` | Date | tracking | When ended |
+| `description` | Text | | Goals |
+| `mentor_karma_per_milestone` | Integer | default=25 | Karma per mentee rank-up |
+| `mentor_karma_on_completion` | Integer | default=100 | Karma bonus on completion |
+| `mentee_milestones_reached` | Integer | readonly | Counter |
+| `total_mentor_karma` | Integer | readonly | Cumulative |
+| `completion_badge_id` | Many2one `badge` | | Badge for both on completion |
+
+**Unique:** `(mentor_id, mentee_id) WHERE state = 'active'`
+
+### State Machine
+
+```
+active ──→ completed (with rewards)
+       └──→ cancelled
+```
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `_compute_display_name()` | Show "X mentoring Y" |
+| `_check_not_self_mentoring()` | Constraint: prevent self-mentoring |
+| `action_complete()` | End mentorship, grant karma + badge to both |
+| `action_cancel()` | Cancel mentorship |
+| `_on_mentee_rank_up(mentee)` | Called by `_rank_changed()` — grants mentor karma |
+| `get_suggested_mentors(limit=5)` | Return higher-karma users for current user |
+
+---
+
+## 17. gamification.quest (+ step, enrollment, step.completion)
+
+**File:** `models/gamification_quest.py`
+**Inherits:** `mail.thread` (quest only)
+**Description:** Multi-step narrative journeys.
+
+### gamification.quest
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Char | required, translate, tracking | Quest name |
+| `description` | Html | translate | Story/narrative |
+| `sequence` | Integer | default=10 | Ordering |
+| `active` | Boolean | default=True | Archivable |
+| `icon` | Image | max 128x128 | Quest icon |
+| `step_ids` | One2many `quest.step` | copy | Ordered steps |
+| `step_count` | Integer | computed | # steps |
+| `reward_badge_id` | Many2one `badge` | | Completion badge |
+| `reward_karma` | Integer | default=0 | Completion karma bonus |
+| `quest_mode` | Selection | `solo/team` | Mode |
+| `difficulty` | Selection | `beginner/intermediate/advanced/expert` | Difficulty |
+| `enrollment_ids` | One2many `quest.enrollment` | | User enrollments |
+| `enrollment_count` | Integer | computed | # enrolled |
+| `completion_count` | Integer | computed | # completed |
+
+### gamification.quest.step
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `quest_id` | Many2one `quest` | Parent |
+| `name` | Char | Step name |
+| `description` | Text | What to do (translate) |
+| `sequence` | Integer | Ordering |
+| `definition_id` | Many2one `goal.definition` | What to accomplish |
+| `target_goal` | Float | Target value |
+| `prerequisite_ids` | Many2many `quest.step` | Must complete before |
+| `karma_reward` | Integer | Per-step karma |
+| `badge_id` | Many2one `badge` | Per-step badge |
+| `skill_node_id` | Many2one `skill.node` | Linked skill tree node |
+
+**Constraint:** `_check_no_self_prerequisite` — a step cannot be its own prerequisite.
+
+### gamification.quest.enrollment
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `quest_id` | Many2one `quest` | Which quest |
+| `user_id` | Many2one `res.users` | Who |
+| `state` | Selection | `in_progress/completed/abandoned` |
+| `progress_percent` | Float | Computed: done steps / total steps |
+| `completion_ids` | One2many `step.completion` | Step records |
+
+**Unique:** `(user_id, quest_id)`
+
+### gamification.quest.step.completion
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `enrollment_id` | Many2one `quest.enrollment` | Which enrollment |
+| `step_id` | Many2one `quest.step` | Which step |
+| `completion_date` | Datetime | When completed (default=now, readonly) |
+
+**Unique:** `(enrollment_id, step_id)`
+
+### Key Methods
+
+| Method | Model | Purpose |
+|--------|-------|---------|
+| `_compute_step_count()` | quest | Count steps |
+| `_compute_enrollment_count()` | quest | Count enrolled + completed users |
+| `complete_step(step)` | quest.enrollment | Validate state + prereqs, create completion, grant rewards, check quest done |
+| `_complete_quest()` | quest.enrollment | Grant quest rewards, log to feed |
+| `action_abandon()` | quest.enrollment | Set state to abandoned |
+
+---
+
+## 18. gamification.season
+
+**File:** `models/gamification_season.py`
+**Inherits:** `mail.thread`
+**Description:** Time-limited themed event with exclusive rewards.
+
+### Fields
+
+| Field | Type | Key Attributes | Purpose |
+|-------|------|----------------|---------|
+| `name` | Char | required, translate, tracking | Season name |
+| `description` | Html | translate | Description |
+| `theme` | Char | translate | Visual theme/motto |
+| `state` | Selection | `draft/active/ended/archived`, tracking, indexed | Lifecycle |
+| `start_date` | Date | required, tracking | Period start |
+| `end_date` | Date | required, tracking | Period end |
+| `icon` | Image | max 128x128 |
+| `challenge_ids` | One2many `challenge` via `season_id` | Season challenges |
+| `badge_ids` | Many2many `badge` | Exclusive badges |
+| `quest_ids` | Many2many `quest` | Season quests |
+| `challenge_count` | Integer | computed | # challenges |
+| `participant_count` | Integer | computed | # unique participants |
+
+### State Machine
+
+```
+draft ──→ active ──→ ended ──→ archived
+```
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `action_activate()` | Start the season |
+| `action_end()` | End the season |
+| `action_archive()` | Archive completed season |
+| `get_season_leaderboard(limit=10)` | Karma earned during season window (SQL, **instance method** — not `@api.model`) |
+
+---
+
+## 19. gamification.skill.tree + skill.node + skill.node.unlock
+
+**File:** `models/gamification_skill.py`
+**Description:** Branching progression paths with prerequisite edges.
+
+### gamification.skill.tree
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `name` | Char | Tree name (e.g., "Sales Mastery") |
+| `description` | Text | What this tree covers |
+| `sequence` | Integer | Ordering |
+| `active` | Boolean | Archivable |
+| `icon` | Image | Tree icon |
+| `color` | Integer | Color index |
+| `node_ids` | One2many `skill.node` | All nodes in tree |
+| `node_count` | Integer | Computed count |
+
+### gamification.skill.node
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `tree_id` | Many2one `skill.tree` | Parent tree |
+| `name` | Char | Skill name |
+| `level` | Integer | Vertical position in tree |
+| `prerequisite_ids` | Many2many `skill.node` | Must unlock before |
+| `dependent_ids` | Many2many `skill.node` | What this unlocks (inverse) |
+| `karma_threshold` | Integer | Min karma required |
+| `quest_id` | Many2one `quest` | Required quest completion |
+| `karma_reward` | Integer | Karma on unlock |
+| `badge_id` | Many2one `badge` | Badge on unlock |
+| `unlock_ids` | One2many `skill.node.unlock` | Tracking |
+| `unlock_count` | Integer | Computed count |
+| `sequence` | Integer | Ordering within level |
+
+### gamification.skill.node.unlock
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `node_id` | Many2one `skill.node` | Which node |
+| `user_id` | Many2one `res.users` | Who unlocked |
+| `unlock_date` | Datetime | When |
+
+**Unique:** `(user_id, node_id)`
+
+### Key Methods
+
+| Method | Purpose |
+|--------|---------|
+| `check_unlock_for_user(user)` | Verify all conditions (prereqs, karma, quest) |
+| `unlock_for_user(user)` | Create unlock, grant rewards, log to feed |

--- a/addons/gamification/models/gamification_challenge_line.py
+++ b/addons/gamification/models/gamification_challenge_line.py
@@ -30,7 +30,7 @@ class GamificationChallengeLine(models.Model):
     sequence = fields.Integer("Sequence", default=1)
     target_goal = fields.Float("Target Value to Reach", required=True)
 
-    name = fields.Char("Name", related="definition_id.name")
+    name = fields.Char("Name", related="definition_id.name", readonly=True)
     condition = fields.Selection(
         string="Condition", related="definition_id.condition", readonly=True
     )

--- a/addons/gamification/static/src/notifications/gamification_notification_service.js
+++ b/addons/gamification/static/src/notifications/gamification_notification_service.js
@@ -14,6 +14,9 @@ export const gamificationNotificationService = {
     start(env, { bus_service, notification }) {
         bus_service.subscribe("gamification/notification", (payload) => {
             const icon = NOTIFICATION_ICONS[payload.type] || "fa-star";
+            // Note: icon is computed above but the notification service API
+            // does not support rendering a custom icon.  The type-specific
+            // className (o_gamification_badge, etc.) can be styled in SCSS.
             notification.add(payload.message, {
                 title: payload.title,
                 type: "success",

--- a/addons/gamification/tests/test_engagement.py
+++ b/addons/gamification/tests/test_engagement.py
@@ -107,16 +107,23 @@ class TestEngagementSnapshot(common.TransactionCase):
         self.assertGreaterEqual(snapshot.badges_granted_7d, 1)
 
     def test_cron_creates_snapshot_per_company(self):
-        """Cron creates snapshots for all companies."""
+        """Cron creates snapshots for all companies with meaningful data."""
         Snapshot = self.env["gamification.engagement.snapshot"]
         Snapshot._cron_record_snapshot()
 
-        count = Snapshot.search_count(
-            [
-                ("company_id", "=", self.company.id),
-            ]
+        snapshot = Snapshot.search(
+            [("company_id", "=", self.company.id)],
+            limit=1,
+            order="snapshot_date desc",
         )
-        self.assertGreaterEqual(count, 1)
+        self.assertTrue(snapshot, "Cron should create at least one snapshot")
+        self.assertEqual(snapshot.company_id, self.company)
+        self.assertTrue(snapshot.snapshot_date, "Snapshot should have a date")
+        # At minimum, active_users should reflect our test users
+        self.assertGreaterEqual(
+            snapshot.total_karma_users, 0,
+            "Snapshot should capture karma user count",
+        )
 
     def test_get_analytics_summary_empty(self):
         """get_analytics_summary returns empty dict when no snapshots exist."""


### PR DESCRIPTION
## Summary

Cherry-pick of [beb0311911b](https://github.com/Agro-Marin/odoo/commit/beb0311911bf301553e58cb6a54045a6ead8f57d) onto `19.0-marin`.

Manual conflict resolution: the audit's ruff-compliance hunks were largely duplicated by commit `5085463` already on `19.0-marin`, and the 3-way merge deduped them. The net-new content that survives:

- `addons/gamification/machine_doc_v1/{architecture,conventions,index,models}.md` — +1712 lines of machine-consumable module docs
- `gamification_challenge_line.py` — explicit `readonly=True` on `name` related field
- `gamification_notification_service.js` — +3 lines
- `tests/test_engagement.py` — +19 lines test coverage

**Total: 7 files, +1729/-7.**

## Conflict resolution notes

9 conflicts (6 UU, 3 AA). All 6 UU hunks were cosmetic ruff-style choices or a test expecting an obsolete `_get_topN_users` signature — resolved in favor of `19.0-marin`'s current state. All 3 AA test files (`test_goal.py`, `test_goal_definition.py`, `test_security.py`) existed identically on both branches modulo ruff formatting — kept the `19.0-marin` version.

## Test plan

- [ ] `odoo-bin -d <db> -u gamification --test-enable --stop-after-init --workers=0`
- [ ] Verify `machine_doc_v1/` renders properly if consumed by tooling
- [ ] Smoke-test gamification UI (challenges, goals, kudos)