### PR TITLE
[REF] mrp: use resource.scheduling.mixin on mrp.workorder

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -15,6 +15,7 @@ from odoo.libs.intervals import Intervals
 class MrpWorkorder(models.Model):
     _name = 'mrp.workorder'
     _description = 'Work Order'
+    _inherit = ['resource.scheduling.mixin']
     _order = 'sequence, reservation_id, date_start, id'
 
     def _default_sequence(self):
@@ -89,6 +90,14 @@ class MrpWorkorder(models.Model):
         compute='_compute_dates',
         inverse='_set_dates',
         store=True, copy=False)
+    # Override mixin's calendar-based allocated_hours with MRP's duration-based version
+    allocated_hours = fields.Float(
+        "Allocated Hours",
+        compute="_compute_allocated_hours",
+        store=True,
+        readonly=False,
+        help="Duration in hours, converted from duration_expected (minutes).",
+    )
     duration_expected = fields.Float(
         'Expected Duration', digits=(16, 2), compute='_compute_duration_expected',
         readonly=False, store=True) # in minutes
@@ -286,7 +295,7 @@ class MrpWorkorder(models.Model):
                 })
             elif wo.date_start:
                 if not wo.date_end:
-                    wo.date_end = wo._calculate_date_finished()
+                    wo.date_end = wo._calculate_date_end()
                 wo.reservation_id = wo.env['resource.reservation'].create({
                     'name': wo.display_name,
                     'resource_id': wo.workcenter_id.resource_id.id,
@@ -346,6 +355,12 @@ class MrpWorkorder(models.Model):
             if workorder.state not in ['done', 'cancel'] and (workorder.qty_producing != workorder.qty_production
                 or (workorder._origin != workorder and workorder._origin.qty_producing and workorder.qty_producing != workorder._origin.qty_producing)):
                 workorder.duration_expected = workorder._get_duration_expected()
+
+    @api.depends('duration_expected')
+    def _compute_allocated_hours(self):
+        """Convert duration_expected (minutes) to hours for mixin compatibility."""
+        for wo in self:
+            wo.allocated_hours = wo.duration_expected / 60.0 if wo.duration_expected else 0.0
 
     @api.depends('time_ids.duration', 'qty_produced')
     def _compute_duration(self):
@@ -446,20 +461,27 @@ class MrpWorkorder(models.Model):
     @api.onchange('date_start', 'duration_expected', 'workcenter_id')
     def _onchange_date_start(self):
         if self.date_start and self.workcenter_id:
-            self.date_end = self._calculate_date_finished()
+            self.date_end = self._calculate_date_end()
 
-    def _calculate_date_finished(self, date_start=False, new_workcenter=False):
+    def _calculate_date_end(self, date_start=False, new_workcenter=False):
+        """Compute work order end date by planning duration forward from start.
+
+        Uses ``_scheduling_plan_hours`` from ``resource.scheduling.mixin`` to
+        respect the workcenter calendar, leaves, and efficiency.
+        Falls back to raw timedelta when the workcenter has no calendar.
+        """
         workcenter = new_workcenter or self.workcenter_id
         if not workcenter.resource_calendar_id:
-            duration_in_seconds = self.duration_expected * 60
-            return (date_start or self.date_start) + timedelta(seconds=duration_in_seconds)
-        return workcenter.resource_calendar_id.plan_hours(
-            self.duration_expected / 60.0, date_start or self.date_start,
-            compute_leaves=True, domain=[('time_type', 'in', ['leave', 'other'])]
+            return (date_start or self.date_start) + timedelta(seconds=self.duration_expected * 60)
+        return self._scheduling_plan_hours(
+            self.duration_expected / 60.0,
+            date_start or self.date_start,
+            calendar=workcenter.resource_calendar_id,
+            leave_domain=[('time_type', 'in', ['leave', 'other'])],
         )
 
     @api.onchange('date_end')
-    def _onchange_date_finished(self):
+    def _onchange_date_end(self):
         if self.date_start and self.date_end and self.workcenter_id:
             self.duration_expected = self._calculate_duration_expected()
         if not self.date_end and self.date_start:
@@ -467,13 +489,22 @@ class MrpWorkorder(models.Model):
                               "You should unplan the Manufacturing Order instead in order to unplan all the linked operations."))
 
     def _calculate_duration_expected(self, date_start=False, date_end=False):
+        """Compute expected duration in minutes from a date range.
+
+        Uses ``_scheduling_get_work_hours`` from ``resource.scheduling.mixin``
+        to respect the workcenter calendar and leaves.
+        Falls back to raw timedelta when the workcenter has no calendar.
+        """
+        start = date_start or self.date_start
+        end = date_end or self.date_end
         if not self.workcenter_id.resource_calendar_id:
-            return ((date_end or self.date_end) - (date_start or self.date_start)).total_seconds() / 60
-        interval = self.workcenter_id.resource_calendar_id.get_work_duration_data(
-            date_start or self.date_start, date_end or self.date_end,
-            domain=[('time_type', 'in', ['leave', 'other'])]
+            return (end - start).total_seconds() / 60
+        hours = self._scheduling_get_work_hours(
+            start, end,
+            calendar=self.workcenter_id.resource_calendar_id,
+            leave_domain=[('time_type', 'in', ['leave', 'other'])],
         )
-        return interval['hours'] * 60
+        return hours * 60
 
     @api.onchange('finished_lot_ids')
     def _onchange_finished_lot_ids(self):
@@ -513,7 +544,7 @@ class MrpWorkorder(models.Model):
                     raise UserError(_('The planned end date of the work order cannot be prior to the planned start date, please correct this to save the work order.'))
                 if 'duration_expected' not in values and not self.env.context.get('bypass_duration_calculation'):
                     if values.get('date_start') and values.get('date_end'):
-                        computed_finished_time = workorder._calculate_date_finished(date_start=date_start, new_workcenter=new_workcenter)
+                        computed_finished_time = workorder._calculate_date_end(date_start=date_start, new_workcenter=new_workcenter)
                         values['date_end'] = computed_finished_time
                     elif date_start and date_end:
                         computed_duration = workorder._calculate_duration_expected(date_start=date_start, date_end=date_end)
@@ -544,7 +575,7 @@ class MrpWorkorder(models.Model):
         for workorder in workorders_with_new_wc:
             workorder.duration_expected = workorder._get_duration_expected()
             if workorder.date_start:
-                workorder.date_end = workorder._calculate_date_finished(new_workcenter=new_workcenter)
+                workorder.date_end = workorder._calculate_date_end(new_workcenter=new_workcenter)
 
         return res
 
@@ -592,7 +623,7 @@ class MrpWorkorder(models.Model):
                 return
         # Consider workcenter and alternatives
         workcenters = self.workcenter_id | self.workcenter_id.alternative_workcenter_ids
-        best_date_finished = datetime.max
+        best_date_end = datetime.max
         vals = {}
         for workcenter in workcenters:
             if not workcenter.resource_calendar_id:
@@ -607,23 +638,23 @@ class MrpWorkorder(models.Model):
             if not from_date:
                 continue
             # Check if this workcenter is better than the previous ones
-            if to_date and to_date < best_date_finished:
+            if to_date and to_date < best_date_end:
                 best_date_start = from_date
-                best_date_finished = to_date
+                best_date_end = to_date
                 best_workcenter = workcenter
                 vals = {
                     'workcenter_id': workcenter.id,
                     'duration_expected': duration_expected,
                 }
         # If none of the workcenter are available, raise
-        if best_date_finished == datetime.max:
+        if best_date_end == datetime.max:
             raise UserError(_('Impossible to plan the workorder. Please check the workcenter availabilities.'))
         # Create reservation on chosen workcenter resource
         reservation = self.env['resource.reservation'].create({
             'name': self.display_name,
             'resource_id': best_workcenter.resource_id.id,
             'date_start': best_date_start,
-            'date_end': best_date_finished,
+            'date_end': best_date_end,
             'allocated_percentage': 100.0,
             'enforcement_mode': 'hard',
             'res_model': 'mrp.workorder',
@@ -696,7 +727,7 @@ class MrpWorkorder(models.Model):
                 wo.write(vals)
             else:
                 if not wo.date_start or wo.date_start > date_start:
-                    vals['date_end'] = wo._calculate_date_finished(date_start)
+                    vals['date_end'] = wo._calculate_date_end(date_start)
                 if wo.date_end and wo.date_end < date_start:
                     vals['date_end'] = date_start
                 wo.with_context(bypass_duration_calculation=True).write(vals)


### PR DESCRIPTION
## Problem

`mrp.workorder` duplicated calendar-aware scheduling logic, calling
`resource_calendar_id.plan_hours` and `get_work_duration_data` directly.
The `resource.scheduling.mixin` already centralizes this for reuse.

Additionally, the helper `_calculate_date_finished` was misnamed — the
field it computes is `date_end`.

## Solution

- Inherit `resource.scheduling.mixin` on `mrp.workorder`.
- Route `_calculate_date_end` and `_calculate_duration_expected` through
  `_scheduling_plan_hours` / `_scheduling_get_work_hours`, falling back
  to raw timedelta when the workcenter has no calendar.
- Rename `_calculate_date_finished` → `_calculate_date_end` (and all
  callers); rename `_onchange_date_finished` → `_onchange_date_end` and
  `best_date_finished` → `best_date_end`.
- Override the mixin's calendar-based `allocated_hours` with a
  `duration_expected`-based compute (minutes → hours) to preserve MRP
  semantics.

## Verification

- [ ] `mrp` module tests pass (`--test-tags /mrp`)
- [ ] Work order planning respects workcenter calendar and leaves
- [ ] Work order planning still works when workcenter has no calendar
- [ ] `allocated_hours` matches `duration_expected / 60` on new and edited WOs