### PR TITLE
[FIX] ruff: add agromarin-addons/** to per-file-ignores for D and ANN

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -297,6 +297,8 @@ ignore = [
 #
 # core/addons/ — standard Odoo modules (account, mail, website, etc.)
 "addons/**" = ["D", "ANN"]
+# agromarin-addons/ — AgroMarin custom modules (lives at ../addons/agromarin-addons/ relative to core/)
+"../addons/agromarin-addons/**" = ["D", "ANN"]
 # core/tests/, core/doc/ — top-level non-package directories
 "tests/**" = ["D", "ANN"]
 "doc/**" = ["D", "ANN"]


### PR DESCRIPTION
# [Task ID: 21027](https://agromarin.mx/odoo/project.task/21027)

## Problem

The `[lint.per-file-ignores]` section suppresses `D` (pydocstyle) and `ANN` (flake8-annotations) for `addons/**`, which covers standard Odoo modules under `core/addons/`. AgroMarin custom modules live at `../addons/agromarin-addons/` relative to `core/`, so the glob never matched — ruff reported D100/D104/ANN violations on every custom module file.

## Solution

Add a single entry alongside the existing `addons/**` line:

```toml
"../addons/agromarin-addons/**" = ["D", "ANN"]
```

ruff's `per-file-ignores` patterns are matched against the path relative to the project root (where `ruff.toml` lives). From `core/`, the relative path to the custom modules repo is `../addons/agromarin-addons/`, so this is the correct glob.

## Verification

- [ ] `ruff check ../addons/agromarin-addons/power_user/ --select D,ANN` → `All checks passed!`
- [ ] Standard Odoo modules in `core/addons/` are unaffected