### PR TITLE
[FIX] ruff: remove invalid selectors RUF065/RUF067/RUF069 blocking linter

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -98,9 +98,12 @@ select = [
 
     # Preview rules (cherry-picked — requires explicit-preview-rules)
     "RUF039",     # unraw-re-pattern (regex missing r"" prefix)
-    "RUF069",     # float-equality-comparison (precision bugs in financial code)
-    "RUF065",     # f-string-in-logging (performance — use lazy %s formatting)
-    # "FURB113",  # repeated-append — DISABLED: loses inter-append comments, rarely a real perf issue
+    # Invalid / non-existent selectors (ruff 0.15 supports up to RUF059):
+    #   RUF065, RUF067, RUF069 — were intended as f-string-in-logging,
+    #   non-empty-init-module and float-equality-comparison but those codes
+    #   do not exist. For f-string logging use G004 (flake8-logging-format);
+    #   non-empty-init-module would penalize Odoo's __init__.py model
+    #   registration so it is intentionally NOT selected.
     "FURB188",    # slice-to-remove-prefix (use removeprefix()/removesuffix())
 
     # Misc
@@ -134,8 +137,6 @@ ignore = [
     "PLW0642",    # self-or-cls-assignment (self = self.sudo() / self.with_context())
     "PLW2901",    # redefined-loop-name (common in Odoo batch processing)
     "TID252",     # relative-imports (Odoo uses them everywhere)
-    "RUF067",     # non-empty-init-module (Odoo requires __init__.py imports)
-
     # --- Ambiguous variable names ---
     "E741",       # ambiguous-variable-name (640 false positives from `lambda l:` — Odoo idiom)
 


### PR DESCRIPTION
# [Task ID: 21042](https://agromarin.mx/odoo/project.task/21042)

## Problem

`ruff.toml` referenced three non-existent rule selectors, causing every `ruff check` that loaded the config to fail with:

```
Unknown rule selector: RUF067
```

ruff 0.15 supports up to RUF059. The three codes were intended as:

| Code used | Intent | Real code / status |
|-----------|--------|--------------------|
| RUF065 | f-string-in-logging | `G004` (flake8-logging-format) |
| RUF067 | non-empty-init-module | Does not exist; intentionally skipped — Odoo `__init__.py` files register models via side-effect imports |
| RUF069 | float-equality-comparison | Does not exist as a ruff rule |

Impact: nobody could run `ruff check` against this repo (or anything below it) until the config was fixed. Any addon workflow that wanted to lint against core's ruff.toml was blocked.

## Solution

- Remove RUF065 / RUF067 / RUF069 from `select` list.
- Leave an explanatory comment documenting why they are absent, so the next person who tries to re-add them sees the rationale.

## Verification

```bash
ruff check /path/to/any/module/   # no longer fails with "Unknown rule selector"
```

Tested against `ruff 0.14.10` and `ruff 0.15.10`, both load the config cleanly.