### PR TITLE
[FIX] pos_hr: guard employeeIsAdmin against undefined cashier

### DIFF
--- a/addons/pos_hr/static/src/app/services/pos_store.js
+++ b/addons/pos_hr/static/src/app/services/pos_store.js
@@ -22,8 +22,14 @@ patch(PosStore.prototype, {
         });
     },
     get employeeIsAdmin() {
+        // Guard against an undefined cashier: when module_pos_hr is enabled,
+        // getCashier() returns this.cashier, which is unset until the user
+        // completes LoginScreen. The Navbar template evaluates employeeIsAdmin
+        // on mount (before any cashier is picked) and would throw
+        // "Cannot read properties of undefined (reading '_role')".
+        // Semantically, no cashier means no admin privileges -> return false.
         const cashier = this.getCashier();
-        return cashier._role === "manager";
+        return cashier?._role === "manager";
     },
     checkPreviousLoggedCashier() {
         if (this.config.module_pos_hr) {


### PR DESCRIPTION
# [Task ID: 21184](https://agromarin.mx/odoo/project.task/21184)

## Problem

When `module_pos_hr` is enabled, `getCashier()` returns `this.cashier`, which is unset until the user completes `LoginScreen`. The Navbar template evaluates `pos.employeeIsAdmin` on mount (before any cashier is picked) and throws:

```
TypeError: Cannot read properties of undefined (reading '_role')
    at get employeeIsAdmin (pos_hr/.../pos_store.js:26)
```

The error is caught by the POS app but surfaces on every boot, cluttering the console and triggering a cascade through the error handler (`Cannot read properties of undefined (reading 'add')` on `env.services.dialog`).

Destaped while fixing [t21118](https://agromarin.mx/odoo/project.task/21118) (POS Balderas edit-existing-lines bug). Previously the POS bundle died earlier in `PosStore.setup()` due to an unrelated addons-side bug, so the Navbar never mounted and this error never fired.

## Solution

Guard the getter with optional chaining. Semantically, no cashier means no admin privileges → return `false`.

```diff
 get employeeIsAdmin() {
     const cashier = this.getCashier();
-    return cashier._role === "manager";
+    return cashier?._role === "manager";
 },
```

## Verification

- [x] POS loads without console errors during LoginScreen phase
- [x] Cashier selection still works
- [x] Admin-gated UI (Close Register, allowProductCreation, canEditPayment) still respects `_role === "manager"` after login