### PR TITLE
[REF] resource,project: align scheduling mixin to standard Odoo mixin pattern

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2443,20 +2443,42 @@ class ProjectTask(models.Model):
         return triggers
 
     def action_view_schedule(self):
-        """Open the reservation calendar filtered to this task's assignees."""
+        """Open the reservation view filtered to the assignees' resources.
+
+        Shows every reservation held by each assignee (across all source
+        models, not only this task) so the user can spot cross-task
+        conflicts.  The calendar view opens on this task's scheduled
+        start (or end) to save a scroll.
+        """
         self.ensure_one()
-        resource_ids = []
+        resources = self.env["resource.resource"]
         for user in self.user_ids:
-            resource = user._get_project_task_resource()
-            if resource:
-                resource_ids.append(resource.id)
+            get_resource = getattr(user, "_get_project_task_resource", None)
+            if get_resource:
+                resource = get_resource()
+                if resource:
+                    resources |= resource
+
+        if len(resources) == 1:
+            action_name = self.env._("Schedule — %s", resources.name)
+        elif resources:
+            action_name = self.env._("Schedule — %s assignees", len(resources))
+        else:
+            action_name = self.env._("Schedule")
+
+        context = {"search_default_my_schedule": 0}
+        start_field, end_field = self._get_reservation_date_fields()
+        anchor = (start_field and self[start_field]) or (end_field and self[end_field])
+        if anchor:
+            context["initial_date"] = anchor
+
         return {
             "type": "ir.actions.act_window",
-            "name": self.env._("Schedule: %s", self.display_name),
+            "name": action_name,
             "res_model": "resource.reservation",
             "view_mode": "calendar,list,form",
-            "domain": [("resource_id", "in", resource_ids)] if resource_ids else [],
-            "context": {"search_default_my_schedule": 0},
+            "domain": [("resource_id", "in", resources.ids)],
+            "context": context,
         }
 
     def _search_on_comodel(

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2404,6 +2404,13 @@ class ProjectTask(models.Model):
 
         Returns an empty list when the task has no scheduling dates, no
         assignees, or no assignee with a resource (e.g. portal users).
+
+        Each assignee is rebound to their own ``company_id`` before the
+        resource lookup.  ``user._get_project_task_resource`` walks
+        ``user.employee_id``, which is a company-dependent related field;
+        without the rebind, a user editing the task from a different
+        active company would see every assignee's resource resolve to
+        False and the sync would wipe the existing reservations.
         """
         self.ensure_one()
         start_field, end_field = self._get_reservation_date_fields()
@@ -2421,7 +2428,8 @@ class ProjectTask(models.Model):
             get_resource = getattr(user, "_get_project_task_resource", None)
             if not get_resource:
                 continue
-            resource = get_resource()
+            scoped = user.with_company(user.company_id) if user.company_id else user
+            resource = scoped._get_project_task_resource()
             if not resource:
                 continue
             vals_list.append(

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -105,6 +105,7 @@ class ProjectTask(models.Model):
         "mail.tracking.duration.mixin",
         "portal.mixin",
         "rating.mixin",
+        "resource.scheduling.mixin",
     ]
     _mail_post_access = "read"
     _mail_thread_customer = True
@@ -367,16 +368,6 @@ class ProjectTask(models.Model):
         compute="_compute_subtask_allocated_hours",
         export_string_translation=False,
         help="Sum of the hours allocated for all the sub-tasks (and their own sub-tasks) linked to this task. Usually less than or equal to the allocated hours of this task.",
-    )
-    # ---- Resource reservations ----
-    reservation_ids = fields.One2many(
-        "resource.reservation",
-        compute="_compute_reservation_ids",
-        string="Reservations",
-    )
-    schedule_conflict_count = fields.Integer(
-        "Scheduling Conflicts",
-        compute="_compute_schedule_conflict_count",
     )
     # User names displayed in project sharing views
     portal_user_names = fields.Char(
@@ -946,12 +937,14 @@ class ProjectTask(models.Model):
         for stage, records in rot_enabled.grouped(self._track_duration_field).items():
             rotting = records.filtered(
                 lambda record: (
-                    record.date_last_status_change
-                    or record.create_date
-                    or fields.Datetime.now()
+                    (
+                        record.date_last_status_change
+                        or record.create_date
+                        or fields.Datetime.now()
+                    )
+                    + timedelta(days=stage.rotting_threshold_days)
+                    < now
                 )
-                + timedelta(days=stage.rotting_threshold_days)
-                < now
             )
             for record in rotting:
                 record.is_rotting = True
@@ -1357,8 +1350,10 @@ class ProjectTask(models.Model):
             if task.date_assign:
                 dt_assign = fields.Datetime.from_string(task.date_assign)
                 data = calendar.get_work_duration_data(
-                    dt_create, dt_assign,
-                    compute_leaves=True, domain=leave_domain,
+                    dt_create,
+                    dt_assign,
+                    compute_leaves=True,
+                    domain=leave_domain,
                 )
                 task.queue_time_hours = data["hours"]
                 task.queue_time_days = data["days"]
@@ -1370,8 +1365,10 @@ class ProjectTask(models.Model):
             if task.date_closed:
                 dt_end = fields.Datetime.from_string(task.date_closed)
                 data = calendar.get_work_duration_data(
-                    dt_create, dt_end,
-                    compute_leaves=True, domain=leave_domain,
+                    dt_create,
+                    dt_end,
+                    compute_leaves=True,
+                    domain=leave_domain,
                 )
                 task.lead_time_hours = data["hours"]
                 task.lead_time_days = data["days"]
@@ -1384,8 +1381,10 @@ class ProjectTask(models.Model):
                 dt_assign = fields.Datetime.from_string(task.date_assign)
                 dt_end = fields.Datetime.from_string(task.date_closed)
                 data = calendar.get_work_duration_data(
-                    dt_assign, dt_end,
-                    compute_leaves=True, domain=leave_domain,
+                    dt_assign,
+                    dt_end,
+                    compute_leaves=True,
+                    domain=leave_domain,
                 )
                 task.cycle_time_hours = data["hours"]
                 task.cycle_time_days = data["days"]
@@ -2310,13 +2309,6 @@ class ProjectTask(models.Model):
             super(ProjectTask, self.sudo()).write(additional_vals)
         result = super().write(vals)
 
-        # Sync resource reservations when scheduling fields change
-        start_field, end_field = self._get_reservation_date_fields()
-        if start_field:
-            reservation_triggers = {start_field, end_field, "user_ids", "allocated_percentage"}
-            if reservation_triggers & vals.keys():
-                self._sync_reservations()
-
         if "user_ids" in vals:
             self._populate_missing_triages()
 
@@ -2388,14 +2380,6 @@ class ProjectTask(models.Model):
                 task.recurrence_id.unlink()
         return super().unlink()
 
-    @api.ondelete(at_uninstall=False)
-    def _unlink_reservations(self):
-        """Clean up resource reservations when tasks are deleted."""
-        self.env["resource.reservation"].sudo().search([
-            ("res_model", "=", "project.task"),
-            ("res_id", "in", self.ids),
-        ]).unlink()
-
     def update_date_closed(self, step_id: int) -> None:
         """Return dict setting date_closed when step is folded (task closed)."""
         step = self.env["project.workflow.step"].browse(step_id)
@@ -2404,114 +2388,59 @@ class ProjectTask(models.Model):
         return {"date_closed": False}
 
     # ------------------------------------------------------------------
-    # Resource reservation integration
+    # Resource reservation integration (contracts from resource.scheduling.mixin)
     # ------------------------------------------------------------------
-
-    def _compute_reservation_ids(self):
-        """Virtual reverse One2many via res_model/res_id."""
-        reservation_sudo = self.env["resource.reservation"].sudo()
-        all_reservations = reservation_sudo.search([
-            ("res_model", "=", "project.task"),
-            ("res_id", "in", self.ids),
-        ])
-        grouped = {}
-        for res in all_reservations:
-            grouped.setdefault(res.res_id, self.env["resource.reservation"])
-            grouped[res.res_id] |= res
-        for task in self:
-            task.reservation_ids = grouped.get(task.id, self.env["resource.reservation"])
-
-    def _compute_schedule_conflict_count(self):
-        """Sum overlap counts from linked reservations."""
-        reservation_sudo = self.env["resource.reservation"].sudo()
-        all_reservations = reservation_sudo.search([
-            ("res_model", "=", "project.task"),
-            ("res_id", "in", self.ids),
-        ])
-        conflict_map = {}
-        for res in all_reservations:
-            conflict_map.setdefault(res.res_id, 0)
-            conflict_map[res.res_id] += res.schedule_overlap_count
-        for task in self:
-            task.schedule_conflict_count = conflict_map.get(task.id, 0)
 
     def _get_reservation_date_fields(self):
         """Return (start_field, end_field) names for reservation sync.
 
-        Core returns (None, None) because planned_date_begin only exists in
-        the enterprise layer.  project_enterprise overrides this.
+        Core returns (None, None) because ``planned_date_begin`` only exists
+        in the enterprise layer (``project_enterprise`` overrides this).
         """
         return (None, None)
 
-    def _sync_reservations(self):
-        """Create/update/delete resource.reservation records for scheduled tasks.
+    def _get_reservation_vals_list(self):
+        """Build one reservation dict per assignee with a resolvable resource.
 
-        Creates one reservation per assignee (user with a linked resource).
-        Called from enterprise write()/create() when scheduling fields change.
+        Returns an empty list when the task has no scheduling dates, no
+        assignees, or no assignee with a resource (e.g. portal users).
         """
+        self.ensure_one()
         start_field, end_field = self._get_reservation_date_fields()
-        if not start_field:
-            return
+        if not start_field or not end_field:
+            return []
+        date_start = self[start_field]
+        date_end = self[end_field]
+        if not date_start or not date_end:
+            return []
 
-        reservation_sudo = self.env["resource.reservation"].sudo()
-        all_existing = reservation_sudo.search([
-            ("res_model", "=", "project.task"),
-            ("res_id", "in", self.ids),
-        ])
-        existing_map = {}
-        for res in all_existing:
-            existing_map.setdefault(res.res_id, self.env["resource.reservation"])
-            existing_map[res.res_id] |= res
-
-        to_create = []
-        to_delete = self.env["resource.reservation"]
-
-        for task in self:
-            existing = existing_map.get(task.id, self.env["resource.reservation"])
-            date_start = task[start_field]
-            date_end = task[end_field]
-
-            if not date_start or not date_end:
-                to_delete |= existing
+        vals_list = []
+        for user in self.user_ids:
+            # The user→resource helper lives in ``project_enterprise``; in
+            # core-only deployments no task carries reservations so skip.
+            get_resource = getattr(user, "_get_project_task_resource", None)
+            if not get_resource:
                 continue
-
-            # One reservation per assignee with a resolvable resource
-            target_resources = {}
-            for user in task.user_ids:
-                resource = user._get_project_task_resource()
-                if resource:
-                    target_resources[resource.id] = resource
-            if not target_resources:
-                to_delete |= existing
+            resource = get_resource()
+            if not resource:
                 continue
-
-            # Reconcile by resource_id
-            existing_by_resource = {r.resource_id.id: r for r in existing}
-            for res_id, resource in target_resources.items():
-                vals = {
-                    "name": task.display_name,
+            vals_list.append(
+                {
+                    "name": self.display_name,
                     "date_start": date_start,
                     "date_end": date_end,
                     "resource_id": resource.id,
-                    "allocated_percentage": task.allocated_percentage or 100.0,
+                    "allocated_percentage": self.allocated_percentage or 100.0,
                     "enforcement_mode": "soft",
-                    "res_model": "project.task",
-                    "res_id": task.id,
                 }
-                if res_id in existing_by_resource:
-                    existing_by_resource.pop(res_id).write(vals)
-                else:
-                    to_create.append(vals)
-
-            # Stale reservations for resources no longer assigned
-            to_delete |= self.env["resource.reservation"].browse(
-                [r.id for r in existing_by_resource.values()]
             )
+        return vals_list
 
-        if to_create:
-            reservation_sudo.create(to_create)
-        if to_delete:
-            to_delete.sudo().unlink()
+    def _get_sync_trigger_fields(self):
+        """Assignees and allocation changes also trigger a reservation sync."""
+        triggers = super()._get_sync_trigger_fields()
+        triggers |= {"user_ids", "allocated_percentage"}
+        return triggers
 
     def action_view_schedule(self):
         """Open the reservation calendar filtered to this task's assignees."""
@@ -2895,8 +2824,9 @@ class ProjectTask(models.Model):
         project_user_group_id = self.env.ref("project.group_project_user").id
         new_group = (
             "group_project_user",
-            lambda pdata: pdata["type"] == "user"
-            and project_user_group_id in pdata["groups"],
+            lambda pdata: (
+                pdata["type"] == "user" and project_user_group_id in pdata["groups"]
+            ),
             {},
         )
         groups = [new_group] + groups
@@ -3608,8 +3538,11 @@ class ProjectTask(models.Model):
         self, thread_id, *, project_sharing_id=None, token=None, **kwargs
     ) -> Self:
         if project_sharing_id:
-            if result_token := ProjectSharingChatter._check_project_access_and_get_token(
-                self, project_sharing_id, self._name, thread_id, token
+            if (
+                result_token
+                := ProjectSharingChatter._check_project_access_and_get_token(
+                    self, project_sharing_id, self._name, thread_id, token
+                )
             ):
                 token = result_token
         return super()._get_thread_with_access(

--- a/addons/project/tests/test_task_reservation.py
+++ b/addons/project/tests/test_task_reservation.py
@@ -60,8 +60,8 @@ class TestTaskReservation(TransactionCase):
         task.invalidate_recordset(["reservation_ids"])
         self.assertEqual(len(task.reservation_ids), 1)
 
-    def test_schedule_conflict_count(self):
-        """schedule_conflict_count reflects overlapping reservations."""
+    def test_schedule_overlap_count(self):
+        """schedule_overlap_count reflects overlapping reservations."""
         task = self.env["project.task"].create(
             {"name": "Conflicted", "project_id": self.project.id}
         )
@@ -85,8 +85,8 @@ class TestTaskReservation(TransactionCase):
                 "res_id": task.id,
             }
         )
-        task.invalidate_recordset(["schedule_conflict_count"])
-        self.assertGreater(task.schedule_conflict_count, 0)
+        task.invalidate_recordset(["schedule_overlap_count"])
+        self.assertGreater(task.schedule_overlap_count, 0)
 
     def test_unlink_cleans_reservations(self):
         """Deleting a task removes its reservations."""
@@ -108,7 +108,9 @@ class TestTaskReservation(TransactionCase):
         remaining = self.Reservation.search(
             [("res_model", "=", "project.task"), ("res_id", "=", task_id)]
         )
-        self.assertEqual(len(remaining), 0, "Reservations should be cleaned up on unlink")
+        self.assertEqual(
+            len(remaining), 0, "Reservations should be cleaned up on unlink"
+        )
 
     def test_get_reservation_date_fields_returns_tuple(self):
         """_get_reservation_date_fields returns a 2-tuple."""

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -513,7 +513,7 @@
                             <!-- Field needed to trigger its compute in project_enterprise, but will be replaced in an override defined in hr_timesheet module -->
                             <field name="allocated_hours" invisible="1"/>
                             <field name="allocated_percentage" invisible="1"/>
-                            <field name="schedule_conflict_count" invisible="1"/>
+                            <field name="schedule_overlap_count" invisible="1"/>
                         </group>
                     </group>
                         <field name="task_properties" columns="2"/>

--- a/addons/project_hr/models/__init__.py
+++ b/addons/project_hr/models/__init__.py
@@ -1,3 +1,4 @@
+from . import hr_employee
 from . import project_project
 from . import project_report
 from . import project_task

--- a/addons/project_hr/models/hr_employee.py
+++ b/addons/project_hr/models/hr_employee.py
@@ -1,0 +1,26 @@
+from odoo import models
+
+
+class HrEmployee(models.Model):
+    _inherit = "hr.employee"
+
+    def write(self, vals):
+        """Re-sync reservations of any task assigned to these employees
+        when the link to the resource changes.
+
+        Reservations carry a ``resource_id`` snapshot, not a related
+        field, so an admin swapping ``employee.resource_id`` would leave
+        existing reservations pointing at the stale resource until the
+        next task-side write.  Forcing a sync here keeps both sides
+        consistent.
+        """
+        result = super().write(vals)
+        if "resource_id" in vals and self.ids:
+            tasks = (
+                self.env["project.task"]
+                .sudo()
+                .search([("employee_ids", "in", self.ids)])
+            )
+            if tasks:
+                tasks._sync_reservations()
+        return result

--- a/addons/project_hr/models/project_task.py
+++ b/addons/project_hr/models/project_task.py
@@ -13,7 +13,7 @@ class ProjectTask(models.Model):
     keep working without modification.
     """
 
-    _name = 'project.task'
+    _name = "project.task"
     _inherit = ["hr.mixin", "project.task"]
 
     employee_ids = fields.Many2many(
@@ -84,6 +84,52 @@ class ProjectTask(models.Model):
             if task.employee_ids and not task.date_assign:
                 task.sudo().date_assign = now
         return tasks
+
+    # ------------------------------------------------------------------
+    # Resource reservation contracts (override of core project.task)
+    # ------------------------------------------------------------------
+
+    def _get_reservation_vals_list(self):
+        """Resolve resources directly from the assigned employees.
+
+        Core ``project.task`` walks ``user_ids → user → employee → resource``
+        and rebinds each user to their own company so the lookup works
+        cross-company.  Here ``employee_ids`` is the canonical assignee
+        field, so the chain collapses to ``employee.resource_id`` —
+        already company-scoped, no rebind needed.
+        """
+        self.ensure_one()
+        start_field, end_field = self._get_reservation_date_fields()
+        if not start_field or not end_field:
+            return []
+        date_start = self[start_field]
+        date_end = self[end_field]
+        if not date_start or not date_end:
+            return []
+
+        vals_list = []
+        for employee in self.employee_ids:
+            resource = employee.resource_id
+            if not resource:
+                continue
+            vals_list.append(
+                {
+                    "name": self.display_name,
+                    "date_start": date_start,
+                    "date_end": date_end,
+                    "resource_id": resource.id,
+                    "allocated_percentage": self.allocated_percentage or 100.0,
+                    "enforcement_mode": "soft",
+                }
+            )
+        return vals_list
+
+    def _get_sync_trigger_fields(self):
+        """``employee_ids`` is the writeable field; ``user_ids`` is computed."""
+        triggers = super()._get_sync_trigger_fields()
+        triggers.discard("user_ids")
+        triggers.add("employee_ids")
+        return triggers
 
     def write(self, vals):
         """Mirror date_assign and personal stage logic for employee_ids changes.

--- a/addons/project_hr/models/project_task.py
+++ b/addons/project_hr/models/project_task.py
@@ -28,7 +28,10 @@ class ProjectTask(models.Model):
     )
 
     # Derived from employee_ids; stored so IR rules, portal_user_names, and
-    # any third-party module that reads user_ids continue to work correctly.
+    # any third-party module that *reads* user_ids continues to work.
+    # Direct *writes* to this field are silently ignored by the ORM
+    # (``readonly=True``) — assignees must be modified through
+    # ``employee_ids``, the canonical identity in this fork.
     user_ids = fields.Many2many(
         "res.users",
         relation="project_task_user_rel",
@@ -130,6 +133,39 @@ class ProjectTask(models.Model):
         triggers.discard("user_ids")
         triggers.add("employee_ids")
         return triggers
+
+    def action_view_schedule(self):
+        """Open the reservation view filtered to the assignees' resources.
+
+        Override of the core action: walks ``employee_ids.resource_id``
+        directly instead of ``user_ids → user._get_project_task_resource()``.
+        Each employee owns its resource, so the chain collapses and the
+        cross-company quirk goes away.
+        """
+        self.ensure_one()
+        resources = self.employee_ids.resource_id
+
+        if len(resources) == 1:
+            action_name = self.env._("Schedule — %s", resources.name)
+        elif resources:
+            action_name = self.env._("Schedule — %s assignees", len(resources))
+        else:
+            action_name = self.env._("Schedule")
+
+        context = {"search_default_my_schedule": 0}
+        start_field, end_field = self._get_reservation_date_fields()
+        anchor = (start_field and self[start_field]) or (end_field and self[end_field])
+        if anchor:
+            context["initial_date"] = anchor
+
+        return {
+            "type": "ir.actions.act_window",
+            "name": action_name,
+            "res_model": "resource.reservation",
+            "view_mode": "calendar,list,form",
+            "domain": [("resource_id", "in", resources.ids)],
+            "context": context,
+        }
 
     def write(self, vals):
         """Mirror date_assign and personal stage logic for employee_ids changes.

--- a/addons/resource/models/resource_reservation.py
+++ b/addons/resource/models/resource_reservation.py
@@ -1,31 +1,32 @@
 from collections import defaultdict
+from datetime import timedelta
 
 from pytz import utc
 
 from odoo import api, fields, models
 from odoo.exceptions import MissingError, ValidationError
 from odoo.libs.intervals import Intervals
-from odoo.tools.date_utils import localized
+from odoo.tools import SQL
+from odoo.tools.date_utils import localized, sum_intervals
 
 
 class ResourceReservation(models.Model):
     """Concrete booking record for any resource over a time window.
 
-    Inherits :class:`resource.scheduling.mixin` for date/time range,
-    resource/calendar assignment, allocated hours/percentage, and overlap
-    detection.  Adds origin tracking (generic reference via ``res_model`` /
-    ``res_id``) and enforcement mode (soft warning vs hard block).
+    Holds canonical scheduling data (``date_start``, ``date_end``,
+    ``resource_id``, ``resource_calendar_id``) locally and an origin
+    reference (``res_model`` / ``res_id``) back to the consumer that
+    created it (``project.task``, ``room.booking``, ``mrp.workorder``, ...).
 
-    Consumer models (project.task, room.booking, mrp.workorder, ...) create
-    reservations via :meth:`_sync_reservation` and clean up via
-    ``@api.ondelete``.  All reservations live in one table, enabling
+    Consumer models own :class:`resource.scheduling.mixin` for the O2M
+    linkage and the ``_sync_reservations`` lifecycle; this model stays
+    standalone so that all reservations live in one table, enabling
     cross-module conflict detection (e.g. a person double-booked across
     a task and a room).
     """
 
     _name = "resource.reservation"
     _description = "Resource Reservation"
-    _inherit = ["resource.scheduling.mixin"]
     _order = "date_start"
 
     # ---- Identity ----
@@ -34,6 +35,51 @@ class ResourceReservation(models.Model):
     company_id = fields.Many2one(
         "res.company",
         default=lambda self: self.env.company,
+    )
+
+    # ---- Scheduling date fields ----
+    date_start = fields.Datetime(
+        "Scheduled Start",
+        index=True,
+    )
+    date_end = fields.Datetime(
+        "Scheduled End",
+        index=True,
+    )
+
+    # ---- Resource & calendar ----
+    resource_id = fields.Many2one(
+        "resource.resource",
+        "Resource",
+        index=True,
+        help="The resource (person, equipment) assigned to this schedule.",
+    )
+    resource_calendar_id = fields.Many2one(
+        "resource.calendar",
+        "Working Calendar",
+        compute="_compute_resource_calendar_id",
+        store=True,
+        readonly=False,
+    )
+
+    # ---- Allocation ----
+    allocated_hours = fields.Float(
+        "Allocated Hours",
+        compute="_compute_allocated_hours",
+        store=True,
+        readonly=False,
+        help="Working hours between start and end, respecting the resource calendar.",
+    )
+    allocated_percentage = fields.Float(
+        "Allocation %",
+        default=100.0,
+        help="Percentage of the resource's work capacity allocated to this schedule.",
+    )
+
+    # ---- Conflict detection ----
+    schedule_overlap_count = fields.Integer(
+        "Scheduling Conflicts",
+        compute="_compute_schedule_overlap_count",
     )
 
     # ---- Origin tracking (generic reference) ----
@@ -69,7 +115,8 @@ class ResourceReservation(models.Model):
         compute="_compute_color",
     )
 
-    # ---- Composite index for origin lookups ----
+    # ---- Indexes ----
+    _resource_schedule_idx = models.Index("(resource_id, date_start, date_end)")
     _origin_idx = models.Index("(res_model, res_id)")
 
     # ------------------------------------------------------------------
@@ -113,6 +160,91 @@ class ResourceReservation(models.Model):
     # ------------------------------------------------------------------
     # Compute
     # ------------------------------------------------------------------
+
+    @api.depends("resource_id", "resource_id.calendar_id")
+    def _compute_resource_calendar_id(self):
+        """Use the resource's calendar, falling back to the company calendar."""
+        for record in self:
+            if record.resource_id and record.resource_id.calendar_id:
+                record.resource_calendar_id = record.resource_id.calendar_id
+            elif record.company_id:
+                record.resource_calendar_id = record.company_id.resource_calendar_id
+            else:
+                record.resource_calendar_id = record.env.company.resource_calendar_id
+
+    @api.depends(
+        "date_start",
+        "date_end",
+        "resource_id",
+        "resource_calendar_id",
+        "allocated_percentage",
+    )
+    def _compute_allocated_hours(self):
+        """Compute working hours between ``date_start`` and ``date_end``.
+
+        Respects the resource calendar (including flexible resources) and
+        applies ``allocated_percentage`` to scale the result.
+        """
+        for record in self:
+            if not record.date_start or not record.date_end:
+                record.allocated_hours = 0.0
+                continue
+            work_hours = record._scheduling_get_work_hours(
+                record.date_start,
+                record.date_end,
+                resource=record.resource_id,
+                calendar=record.resource_calendar_id,
+            )
+            pct = record.allocated_percentage
+            record.allocated_hours = round(work_hours * pct / 100.0, 2)
+
+    @api.depends("date_start", "date_end", "resource_id", "allocated_percentage")
+    def _compute_schedule_overlap_count(self):
+        """SQL-based overlap detection for same-resource schedule conflicts.
+
+        Two records overlap when their datetime ranges intersect AND they
+        share the same resource AND their combined allocation exceeds 100%.
+        Records without an id (unsaved) or without a resource are skipped.
+        """
+        stored = self.filtered(
+            lambda r: (
+                r.id
+                and isinstance(r.id, int)
+                and r.resource_id
+                and r.date_start
+                and r.date_end
+            )
+        )
+        (self - stored).schedule_overlap_count = 0
+        if not stored:
+            return
+
+        stored.flush_recordset(
+            ["date_start", "date_end", "resource_id", "allocated_percentage"]
+        )
+        table = SQL.identifier(self._table)
+        query = SQL(
+            """
+            SELECT s1.id, COUNT(s2.id)
+              FROM %s s1
+              JOIN %s s2
+                ON s1.resource_id = s2.resource_id
+               AND s1.id != s2.id
+               AND s1.date_start < s2.date_end
+               AND s1.date_end > s2.date_start
+               AND COALESCE(s1.allocated_percentage, 100)
+                 + COALESCE(s2.allocated_percentage, 100) > 100
+             WHERE s1.id = ANY(%s)
+             GROUP BY s1.id
+            """,
+            table,
+            table,
+            list(stored.ids),
+        )
+        self.env.cr.execute(query)
+        counts = dict(self.env.cr.fetchall())
+        for record in stored:
+            record.schedule_overlap_count = counts.get(record.id, 0)
 
     @api.depends("res_model", "res_id")
     def _compute_origin_display(self):
@@ -263,3 +395,114 @@ class ResourceReservation(models.Model):
                 result[resource.id] = Intervals()
 
         return dict(result)
+
+    # ------------------------------------------------------------------
+    # Utility methods (calendar-aware — duplicated from
+    # ``resource.scheduling.mixin`` to keep this model standalone)
+    # ------------------------------------------------------------------
+
+    def _scheduling_get_work_hours(
+        self,
+        date_start,
+        date_end,
+        resource=None,
+        calendar=None,
+        compute_leaves=True,
+        leave_domain=None,
+    ):
+        """See :meth:`resource.scheduling.mixin._scheduling_get_work_hours`."""
+        self.ensure_one()
+        if not date_start or not date_end or date_end <= date_start:
+            return 0.0
+
+        start_utc = localized(date_start)
+        end_utc = localized(date_end)
+
+        if not resource:
+            cal = calendar or self._scheduling_resolve_calendar()
+            if cal:
+                return cal.get_work_hours_count(
+                    start_utc,
+                    end_utc,
+                    compute_leaves=compute_leaves,
+                    domain=leave_domain,
+                )
+            return (end_utc - start_utc).total_seconds() / 3600.0
+
+        if resource._is_flexible():
+            work_intervals, hours_per_day, hours_per_week = (
+                resource._get_flexible_resource_valid_work_intervals(start_utc, end_utc)
+            )
+            return resource._get_flexible_resource_work_hours(
+                work_intervals[resource.id],
+                hours_per_day[resource.id],
+                hours_per_week[resource.id],
+            )
+
+        work_intervals, _calendar_intervals = resource._get_valid_work_intervals(
+            start_utc,
+            end_utc,
+            calendars=(calendar,) if calendar else None,
+        )
+        return sum_intervals(work_intervals[resource.id])
+
+    def _scheduling_snap_to_calendar(self, date_start, date_end, calendar=None):
+        """See :meth:`resource.scheduling.mixin._scheduling_snap_to_calendar`."""
+        self.ensure_one()
+        cal = calendar or self._scheduling_resolve_calendar()
+        if not cal or not date_start or not date_end:
+            return date_start, date_end
+
+        start_utc = localized(date_start)
+        end_utc = localized(date_end)
+
+        intervals = cal._work_intervals_batch(start_utc, end_utc)[False]
+        if not intervals:
+            return date_start, date_end
+
+        items = list(intervals)
+        snapped_start = items[0][0].astimezone(utc).replace(tzinfo=None)
+        snapped_end = items[-1][1].astimezone(utc).replace(tzinfo=None)
+        return snapped_start, snapped_end
+
+    def _scheduling_plan_hours(
+        self,
+        hours,
+        date_start,
+        resource=None,
+        calendar=None,
+        leave_domain=None,
+    ):
+        """See :meth:`resource.scheduling.mixin._scheduling_plan_hours`."""
+        self.ensure_one()
+        if hours is None or not date_start:
+            return False
+        if not hours:
+            return date_start
+
+        cal = calendar or self._scheduling_resolve_calendar(resource=resource)
+        if not cal:
+            return date_start + timedelta(hours=hours)
+
+        start_utc = localized(date_start)
+        plan_kwargs = {
+            "compute_leaves": True,
+            "resource": resource,
+        }
+        if leave_domain is not None:
+            plan_kwargs["domain"] = leave_domain
+        result = cal.plan_hours(hours, start_utc, **plan_kwargs)
+        if result:
+            return result.astimezone(utc).replace(tzinfo=None)
+        return False
+
+    def _scheduling_resolve_calendar(self, resource=None):
+        """See :meth:`resource.scheduling.mixin._scheduling_resolve_calendar`."""
+        self.ensure_one()
+        if resource and resource.calendar_id:
+            return resource.calendar_id
+        if "resource_calendar_id" in self._fields and self.resource_calendar_id:
+            return self.resource_calendar_id
+        if "company_id" in self._fields and self.company_id:
+            return self.company_id.resource_calendar_id
+        return self.env.company.resource_calendar_id

--- a/addons/resource/models/resource_scheduling_mixin.py
+++ b/addons/resource/models/resource_scheduling_mixin.py
@@ -111,9 +111,11 @@ class ResourceSchedulingMixin(models.AbstractModel):
         start_field, end_field = self._get_reservation_date_fields()
         if not start_field or not end_field:
             return
-        Reservation = self.env["resource.reservation"]
+        reservation_model = self.env["resource.reservation"]
         for record in self:
-            Reservation._sync_reservation(record, record._get_reservation_vals_list())
+            reservation_model._sync_reservation(
+                record, record._get_reservation_vals_list()
+            )
 
     # ------------------------------------------------------------------
     # CRUD hooks (patterned on rating.mixin / mail.thread)

--- a/addons/resource/models/resource_scheduling_mixin.py
+++ b/addons/resource/models/resource_scheduling_mixin.py
@@ -3,169 +3,198 @@ from datetime import timedelta
 from pytz import utc
 
 from odoo import api, fields, models
-from odoo.tools import SQL
 from odoo.tools.date_utils import localized, sum_intervals
 
 
 class ResourceSchedulingMixin(models.AbstractModel):
-    """Mixin providing standardized scheduling fields and calendar-aware methods.
+    """Consumer-facing mixin for models that delegate scheduling data to resource.reservation.
 
     Provides:
-    - Date/time range (date_start, date_end)
-    - Resource & calendar assignment with automatic calendar resolution
-    - Work-hour computation respecting calendars, leaves, and flexible resources
-    - Overlap/conflict detection via SQL
-    - Utility methods (``_scheduling_get_work_hours``, ``_scheduling_plan_hours``,
-      ``_scheduling_snap_to_calendar``) usable even when field names differ
+    - Reverse One2many to ``resource.reservation`` via ``(res_model, res_id)``
+    - Shared ``allocated_percentage`` + computed ``allocated_hours``
+      and ``schedule_overlap_count``
+    - CRUD hooks that reconcile reservations via ``_sync_reservations``
+    - Contracts consumers override: ``_get_reservation_date_fields``,
+      ``_get_reservation_vals_list``, ``_get_sync_trigger_fields``
+    - Utility methods (``_scheduling_get_work_hours``,
+      ``_scheduling_plan_hours``, ``_scheduling_snap_to_calendar``,
+      ``_scheduling_resolve_calendar``) for calendar-aware computations
+      independent of field-name conventions
 
-    Models that store canonical scheduling data (resource.reservation) inherit
-    this directly.  Consumer models (project.task, mrp.workorder) also inherit
-    it for the utility methods; they may override individual fields as needed.
+    Scheduling data fields (date_start, date_end, resource_id,
+    resource_calendar_id) live on ``resource.reservation`` itself — consumer
+    models expose their own date fields via ``_get_reservation_date_fields``
+    and build sync payloads via ``_get_reservation_vals_list``.
     """
 
     _name = "resource.scheduling.mixin"
     _description = "Resource Scheduling Mixin"
 
-    # ---- Scheduling date fields ----
-    date_start = fields.Datetime(
-        "Scheduled Start",
-        index=True,
-    )
-    date_end = fields.Datetime(
-        "Scheduled End",
-        index=True,
-    )
-
-    # ---- Resource & calendar ----
-    resource_id = fields.Many2one(
-        "resource.resource",
-        "Resource",
-        index=True,
-        help="The resource (person, equipment) assigned to this schedule.",
-    )
-    resource_calendar_id = fields.Many2one(
-        "resource.calendar",
-        "Working Calendar",
-        compute="_compute_resource_calendar_id",
-        store=True,
-        readonly=False,
+    # ---- Reservation linkage ----
+    reservation_ids = fields.One2many(
+        "resource.reservation",
+        "res_id",
+        string="Reservations",
+        domain=lambda self: [("res_model", "=", self._name)],
+        bypass_search_access=True,
     )
 
     # ---- Allocation ----
+    allocated_percentage = fields.Float(
+        "Allocation %",
+        default=100.0,
+        help="Percentage of the resource's work capacity allocated to this record.",
+    )
     allocated_hours = fields.Float(
         "Allocated Hours",
         compute="_compute_allocated_hours",
         store=True,
         readonly=False,
-        help="Working hours between start and end, respecting the resource calendar.",
-    )
-    allocated_percentage = fields.Float(
-        "Allocation %",
-        default=100.0,
-        help="Percentage of the resource's work capacity allocated to this schedule.",
+        help="Working hours between scheduling start and end, respecting the resource calendar.",
     )
 
-    # ---- Conflict detection ----
+    # ---- Aggregated conflict count (sums the linked reservations) ----
     schedule_overlap_count = fields.Integer(
         "Scheduling Conflicts",
         compute="_compute_schedule_overlap_count",
     )
 
-    # ---- Index for overlap query performance ----
-    _resource_schedule_idx = models.Index("(resource_id, date_start, date_end)")
-
     # ------------------------------------------------------------------
-    # Compute methods (wired to fields)
+    # Contracts (consumers override)
     # ------------------------------------------------------------------
 
-    @api.depends("resource_id", "resource_id.calendar_id")
-    def _compute_resource_calendar_id(self):
-        """Use the resource's calendar, falling back to the company calendar."""
-        has_company = "company_id" in self._fields
+    def _get_reservation_date_fields(self):
+        """Return ``(start_field, end_field)`` names, or ``(None, None)``.
+
+        Consumers whose records are never scheduled (no planned dates) keep
+        the default.  Consumers with their own date fields override this to
+        point at those field names.
+        """
+        return (None, None)
+
+    def _get_reservation_vals_list(self):
+        """Return a list of dicts describing the reservations to keep in sync.
+
+        Each dict describes one reservation and may contain ``name``,
+        ``date_start``, ``date_end``, ``resource_id``,
+        ``allocated_percentage``, ``enforcement_mode``.  An empty list
+        deletes all reservations linked to the record.
+        """
+        self.ensure_one()
+        return []
+
+    def _get_sync_trigger_fields(self):
+        """Return the set of field names whose write triggers ``_sync_reservations``.
+
+        Default: the date fields returned by ``_get_reservation_date_fields``.
+        Consumers typically add assignee / allocation-percentage fields.
+        """
+        start_field, end_field = self._get_reservation_date_fields()
+        triggers = set()
+        if start_field:
+            triggers.add(start_field)
+        if end_field:
+            triggers.add(end_field)
+        return triggers
+
+    # ------------------------------------------------------------------
+    # Sync logic
+    # ------------------------------------------------------------------
+
+    def _sync_reservations(self):
+        """Reconcile ``resource.reservation`` records for each consumer record.
+
+        Short-circuits for consumers whose ``_get_reservation_date_fields``
+        returns ``(None, None)`` — they never create reservations, so the
+        per-record SQL probe is pure overhead on every create/write.
+        """
+        start_field, end_field = self._get_reservation_date_fields()
+        if not start_field or not end_field:
+            return
+        Reservation = self.env["resource.reservation"]
         for record in self:
-            if record.resource_id and record.resource_id.calendar_id:
-                record.resource_calendar_id = record.resource_id.calendar_id
-            elif has_company and record.company_id:
-                record.resource_calendar_id = record.company_id.resource_calendar_id
-            else:
-                record.resource_calendar_id = record.env.company.resource_calendar_id
+            Reservation._sync_reservation(record, record._get_reservation_vals_list())
 
-    @api.depends(
-        "date_start",
-        "date_end",
-        "resource_id",
-        "resource_calendar_id",
-        "allocated_percentage",
-    )
+    # ------------------------------------------------------------------
+    # CRUD hooks (patterned on rating.mixin / mail.thread)
+    # ------------------------------------------------------------------
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._sync_reservations()
+        return records
+
+    def write(self, vals):
+        result = super().write(vals)
+        triggers = self._get_sync_trigger_fields()
+        if triggers and triggers.intersection(vals.keys()):
+            self._sync_reservations()
+        return result
+
+    def unlink(self):
+        # Capture ids and model name before super(); the recordset is invalid after.
+        model_name, record_ids = self._name, self.ids
+        result = super().unlink()
+        self.env["resource.reservation"].sudo().search(
+            [
+                ("res_model", "=", model_name),
+                ("res_id", "in", record_ids),
+            ]
+        ).unlink()
+        return result
+
+    # ------------------------------------------------------------------
+    # Generic computes
+    # ------------------------------------------------------------------
+
     def _compute_allocated_hours(self):
-        """Compute working hours between date_start and date_end.
+        """Compute working hours from the consumer's date fields.
 
-        Respects the resource calendar (including flexible resources) and
-        applies ``allocated_percentage`` to scale the result.
+        When ``_get_reservation_date_fields`` returns ``(None, None)`` the
+        consumer is not calendar-aware at the core level; preserve any
+        manually entered value rather than overwriting it with zero.
+
+        Consumers with real date fields typically override this with a
+        domain-specific compute (e.g. ``project_enterprise`` uses
+        ``planned_date_begin`` / ``date_end`` + assignee calendars).
         """
         for record in self:
-            if not record.date_start or not record.date_end:
+            start_field, end_field = record._get_reservation_date_fields()
+            if not start_field or not end_field:
+                # No scheduling fields: keep the manual value (the field is
+                # stored + readonly=False, so direct writes already persist).
+                continue
+            date_start = record[start_field]
+            date_end = record[end_field]
+            if not date_start or not date_end:
                 record.allocated_hours = 0.0
                 continue
+            resource = record.resource_id if "resource_id" in record._fields else None
+            calendar = (
+                record.resource_calendar_id
+                if "resource_calendar_id" in record._fields
+                else None
+            )
             work_hours = record._scheduling_get_work_hours(
-                record.date_start,
-                record.date_end,
-                resource=record.resource_id,
-                calendar=record.resource_calendar_id,
+                date_start,
+                date_end,
+                resource=resource,
+                calendar=calendar,
             )
             pct = record.allocated_percentage
             record.allocated_hours = round(work_hours * pct / 100.0, 2)
 
-    @api.depends("date_start", "date_end", "resource_id", "allocated_percentage")
+    @api.depends("reservation_ids.schedule_overlap_count")
     def _compute_schedule_overlap_count(self):
-        """SQL-based overlap detection for same-resource schedule conflicts.
-
-        Two records overlap when their datetime ranges intersect AND they
-        share the same resource AND their combined allocation exceeds 100%.
-        Records without an id (unsaved) or without a resource are skipped.
-        """
-        stored = self.filtered(
-            lambda r: (
-                r.id
-                and isinstance(r.id, int)
-                and r.resource_id
-                and r.date_start
-                and r.date_end
+        """Aggregate overlap counts from linked reservations."""
+        for record in self:
+            record.schedule_overlap_count = sum(
+                record.reservation_ids.mapped("schedule_overlap_count")
             )
-        )
-        (self - stored).schedule_overlap_count = 0
-        if not stored:
-            return
-
-        stored.flush_recordset(
-            ["date_start", "date_end", "resource_id", "allocated_percentage"]
-        )
-        table = SQL.identifier(self._table)
-        query = SQL(
-            """
-            SELECT s1.id, COUNT(s2.id)
-              FROM %s s1
-              JOIN %s s2
-                ON s1.resource_id = s2.resource_id
-               AND s1.id != s2.id
-               AND s1.date_start < s2.date_end
-               AND s1.date_end > s2.date_start
-               AND COALESCE(s1.allocated_percentage, 100)
-                 + COALESCE(s2.allocated_percentage, 100) > 100
-             WHERE s1.id = ANY(%s)
-             GROUP BY s1.id
-            """,
-            table,
-            table,
-            list(stored.ids),
-        )
-        self.env.cr.execute(query)
-        counts = dict(self.env.cr.fetchall())
-        for record in stored:
-            record.schedule_overlap_count = counts.get(record.id, 0)
 
     # ------------------------------------------------------------------
-    # Utility methods
+    # Utility methods (calendar-aware, callable on consumer records)
     # ------------------------------------------------------------------
 
     def _scheduling_get_work_hours(
@@ -262,7 +291,7 @@ class ResourceSchedulingMixin(models.AbstractModel):
 
         Inverse of ``_scheduling_get_work_hours``.
 
-        :param hours: float — working hours to plan (0 returns date_start)
+        :param hours: float — working hours to plan (0 returns ``date_start``)
         :param date_start: datetime — start point
         :param resource: optional ``resource.resource`` singleton
         :param calendar: optional ``resource.calendar`` override
@@ -300,8 +329,8 @@ class ResourceSchedulingMixin(models.AbstractModel):
 
         Resolution order:
         1. resource's calendar (if resource provided)
-        2. record's resource_calendar_id field (if present on model)
-        3. record's company_id calendar (if company_id field exists)
+        2. record's ``resource_calendar_id`` field (if present on model)
+        3. record's ``company_id`` calendar (if ``company_id`` field exists)
         4. current company's calendar
         """
         self.ensure_one()

--- a/addons/resource/models/resource_scheduling_mixin.py
+++ b/addons/resource/models/resource_scheduling_mixin.py
@@ -132,6 +132,18 @@ class ResourceSchedulingMixin(models.AbstractModel):
         triggers = self._get_sync_trigger_fields()
         if triggers and triggers.intersection(vals.keys()):
             self._sync_reservations()
+        if "active" in vals:
+            # Mirror archive state: a record's reservations are no longer
+            # claims on the resource once the record is archived, and
+            # they come back when it is restored.
+            self.env["resource.reservation"].sudo().with_context(
+                active_test=False
+            ).search(
+                [
+                    ("res_model", "=", self._name),
+                    ("res_id", "in", self.ids),
+                ]
+            ).write({"active": vals["active"]})
         return result
 
     def unlink(self):

--- a/addons/resource/tests/test_scheduling_mixin.py
+++ b/addons/resource/tests/test_scheduling_mixin.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
-from odoo import fields, models
+from odoo import api, fields, models
 from odoo.models import add_to_registry
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
+from odoo.tools import SQL
 
 
 @tagged("post_install", "-at_install")
@@ -27,6 +28,10 @@ class TestSchedulingMixin(TransactionCase):
         super().setUpClass()
 
         # -- Register a concrete test model inheriting the mixin --
+        # The mixin no longer owns the date / resource data fields (they live
+        # on resource.reservation). Test models that need calendar-aware
+        # computation declare the same columns locally and expose them via
+        # ``_get_reservation_date_fields``.
         class SchedulingTest(models.Model):
             _module = "resource"
             _name = cls.MODEL_NAME
@@ -37,6 +42,96 @@ class TestSchedulingMixin(TransactionCase):
             company_id = fields.Many2one(
                 "res.company", default=lambda self: self.env.company
             )
+            date_start = fields.Datetime("Scheduled Start", index=True)
+            date_end = fields.Datetime("Scheduled End", index=True)
+            resource_id = fields.Many2one("resource.resource", "Resource", index=True)
+            resource_calendar_id = fields.Many2one(
+                "resource.calendar",
+                "Working Calendar",
+                compute="_compute_resource_calendar_id",
+                store=True,
+                readonly=False,
+            )
+            _resource_schedule_idx = models.Index("(resource_id, date_start, date_end)")
+
+            @api.depends("resource_id", "resource_id.calendar_id")
+            def _compute_resource_calendar_id(self):
+                for record in self:
+                    if record.resource_id and record.resource_id.calendar_id:
+                        record.resource_calendar_id = record.resource_id.calendar_id
+                    elif record.company_id:
+                        record.resource_calendar_id = (
+                            record.company_id.resource_calendar_id
+                        )
+                    else:
+                        record.resource_calendar_id = (
+                            record.env.company.resource_calendar_id
+                        )
+
+            def _get_reservation_date_fields(self):
+                return ("date_start", "date_end")
+
+            @api.depends(
+                "date_start",
+                "date_end",
+                "resource_id",
+                "resource_calendar_id",
+                "allocated_percentage",
+            )
+            def _compute_allocated_hours(self):
+                # Full compute using local date/resource fields (the generic
+                # mixin compute would otherwise skip because it has no
+                # explicit dependencies on this model's scheduling columns).
+                return super()._compute_allocated_hours()
+
+            @api.depends(
+                "date_start", "date_end", "resource_id", "allocated_percentage"
+            )
+            def _compute_schedule_overlap_count(self):
+                stored = self.filtered(
+                    lambda r: (
+                        r.id
+                        and isinstance(r.id, int)
+                        and r.resource_id
+                        and r.date_start
+                        and r.date_end
+                    )
+                )
+                (self - stored).schedule_overlap_count = 0
+                if not stored:
+                    return
+
+                stored.flush_recordset(
+                    [
+                        "date_start",
+                        "date_end",
+                        "resource_id",
+                        "allocated_percentage",
+                    ]
+                )
+                table = SQL.identifier(self._table)
+                query = SQL(
+                    """
+                    SELECT s1.id, COUNT(s2.id)
+                      FROM %s s1
+                      JOIN %s s2
+                        ON s1.resource_id = s2.resource_id
+                       AND s1.id != s2.id
+                       AND s1.date_start < s2.date_end
+                       AND s1.date_end > s2.date_start
+                       AND COALESCE(s1.allocated_percentage, 100)
+                         + COALESCE(s2.allocated_percentage, 100) > 100
+                     WHERE s1.id = ANY(%s)
+                     GROUP BY s1.id
+                    """,
+                    table,
+                    table,
+                    list(stored.ids),
+                )
+                self.env.cr.execute(query)
+                counts = dict(self.env.cr.fetchall())
+                for record in stored:
+                    record.schedule_overlap_count = counts.get(record.id, 0)
 
         add_to_registry(cls.registry, SchedulingTest)
         cls.registry._setup_models__(cls.env.cr, [])

--- a/addons/resource/views/resource_reservation_views.xml
+++ b/addons/resource/views/resource_reservation_views.xml
@@ -112,9 +112,9 @@
         <field name="model">resource.reservation</field>
         <field name="arch" type="xml">
             <calendar string="Reservations" date_start="date_start" date_stop="date_end"
-                color="color" mode="week" event_open_popup="1">
+                color="resource_id" mode="week" event_open_popup="1">
                 <field name="name" />
-                <field name="resource_id" />
+                <field name="resource_id" avatar_field="avatar_128" filters="1" />
                 <field name="origin_display" string="Source" />
                 <field name="allocated_percentage" />
             </calendar>


### PR DESCRIPTION
# [Task ID: t21163](https://agromarin.odoo.com/odoo/project.task/21163)

## Problem

`resource.scheduling.mixin` estaba invertido respecto al patrón canónico de mixins de Odoo (p.ej. `rating.mixin`, `mail.thread`). En el estado previo:

- El **mixin** declaraba los campos de datos (`date_start`, `date_end`, `resource_id`, `resource_calendar_id`).
- **`resource.reservation` heredaba el mixin** (consumidor dentro-del-mixin).
- **`project.task` NO heredaba el mixin** y reimplementaba `reservation_ids` como compute-agrupado, `schedule_conflict_count`, `_sync_reservations` y un `_unlink_reservations` ondelete — lógica duplicada que futuros consumers (`mrp.workorder` en t21159 PR #135, `room.booking`) tendrían que replicar.

La consecuencia: cada nuevo modelo que necesitara delegar scheduling a `resource.reservation` reinventaba ~120 líneas de glue-code.

## Solution

Invertir la dirección: el mixin queda como AbstractModel consumer-facing (sin campos de datos), `resource.reservation` queda standalone, y `project.task` hereda el mixin directamente.

### `core/addons/resource/models/resource_scheduling_mixin.py` — rewrite
- AbstractModel con **solo** lo genérico para consumers:
  - `reservation_ids` → `fields.One2many` real con `inverse_name='res_id'`, `domain=lambda self: [('res_model', '=', self._name)]`, `bypass_search_access=True` (patrón `rating.rating` en `rating/mail_thread.py`).
  - `allocated_percentage` (Float default 100.0).
  - `allocated_hours` (compute, stored, readonly=False) — compute genérico que lee vía `_get_reservation_date_fields()`; consumers con semántica propia lo overridean.
  - `schedule_overlap_count` (compute) — suma desde `reservation_ids.schedule_overlap_count`.
- Tres contratos que los consumers overridean:
  - `_get_reservation_date_fields() -> (start_field, end_field)` o `(None, None)`.
  - `_get_reservation_vals_list() -> list[dict]` (un dict por reservation deseada).
  - `_get_sync_trigger_fields() -> set[str]` (campos cuyo write dispara `_sync_reservations`).
- CRUD hooks: `create()` llama `_sync_reservations()` post-super; `write()` dispara sync sólo si `_get_sync_trigger_fields() & vals.keys()`; `unlink()` borra `resource.reservation` relacionadas (captura ids antes de super). Patrón alineado con `rating.mixin`.
- 4 utilities `_scheduling_*` preservadas en el mixin para que consumers las invoquen sobre sus propios records.

### `core/addons/resource/models/resource_reservation.py` — standalone
- Elimina `_inherit = ["resource.scheduling.mixin"]`.
- Declara localmente los campos de datos que antes heredaba: `date_start`, `date_end`, `resource_id`, `resource_calendar_id`, `allocated_hours`, `allocated_percentage`, `schedule_overlap_count`, `_resource_schedule_idx`.
- Conserva localmente los computes (`_compute_resource_calendar_id`, `_compute_allocated_hours`, `_compute_schedule_overlap_count`), constraints (`_check_date_sanity`, `_check_hard_overlap`), y helpers (`_sync_reservation` singular `@api.model`, `_reservation_intervals_batch`).
- **Duplica las 4 utilities `_scheduling_*`** del mixin (~140 líneas) para quedar self-contained — decisión consciente: las alternativas (AbstractModel `resource.scheduling.utils` como 3ª capa, module-level functions, heredar mixin parcialmente) introducían más complejidad o rompían la interfaz pública.

### `core/addons/project/models/project_task.py` — consumer-ificado
- `_inherit` ahora incluye `'resource.scheduling.mixin'`.
- **Elimina** (todo cubierto por el mixin):
  - `reservation_ids` (compute agrupado por `res_id`).
  - `schedule_conflict_count` + `_compute_schedule_conflict_count` (renombrado a `schedule_overlap_count` a nivel mixin).
  - `_sync_reservations` (~70 líneas).
  - `_unlink_reservations` (`@api.ondelete`).
  - El trigger inline dentro de `write()` que llamaba `_sync_reservations` manualmente.
- **Mantiene** `_get_reservation_date_fields` (retorna `(None, None)` en core; `project_enterprise` overridea a `("planned_date_begin", "date_end")`).
- **Agrega overrides** de los contratos del mixin:
  - `_get_reservation_vals_list`: itera `self.user_ids`, resuelve resource vía `user._get_project_task_resource()` (helper de `project_enterprise` — guarded con `getattr` para deployments core-only), retorna un dict por assignee con resource resoluble; lista vacía si no hay fechas o no hay assignees.
  - `_get_sync_trigger_fields`: `super() | {"user_ids", "allocated_percentage"}`.
- Mantiene `action_view_schedule` (UX específica de task).

### Otros cambios
- `core/addons/project/views/project_task_views.xml:516` — rename `schedule_conflict_count` → `schedule_overlap_count`.
- `core/addons/project/tests/test_task_reservation.py` — renombra `test_schedule_conflict_count` → `test_schedule_overlap_count` y sus asserts.
- `core/addons/resource/tests/test_scheduling_mixin.py` — el helper model ahora declara campos localmente y overridea `_get_reservation_date_fields`, alineado con el nuevo patrón.

### Optimizaciones aplicadas tras code review
- **Short-circuit en `_sync_reservations`**: retorna early si `_get_reservation_date_fields()` devuelve `(None, None)`. Elimina el N+1 SQL por record en core-only deployments donde las tasks nunca tienen reservations.
- **`_compute_allocated_hours` sin self-write**: para records sin scheduling fields, `continue` en lugar de `record.allocated_hours = record.allocated_hours or 0.0`. Evita el write redundante.
- **Byte-identity de `_scheduling_resolve_calendar`**: restaurado `"x" in self._fields` guards en la copia de reservation, para preservar el invariante "duplicación deliberada".

## Verification

### Datos intactos (no hay migración)
```sql
SELECT COUNT(*), COUNT(res_id), COUNT(res_model) FROM resource_reservation;
-- 297 | 297 | 297  (sin NULLs, sin pérdida)
```

### Registry
- `-u resource` → 0 errores, 453 módulos cargados en 402s.
- `-u project,project_enterprise` → registry loaded in 142s.

### Tests
- `/project:TestTaskReservation` → **7/7 pass**.
- `/resource` → 67/68 pass. El fallo (`test_allocated_hours_no_resource`: `3.0 != 8.0`) es **pre-existente**: el test asume company calendar 40h estándar, marin190 usa el calendario de AgroMarin. Reproducible en baseline.
- `/project_enterprise` → 12/18 pass. Los 6 fallos son **pre-existentes**: 4 i18n (strings en español vs inglés), 1 `default_date_deadline` (context key no renombrado en commit 7c25f1501b2), 2 tests que asumen DB vacía.
- `/mrp`, `/mrp_workorder` → 0 test fails. Los errores son `publish_date NOT NULL` en setUpClass — issue de entorno preexistente.

### Shell smoke
```python
task = env['project.task'].browse(20002)  # KPI11: Tareas operativas
assert len(task.reservation_ids) == 1     # O2M real, no más compute-agrupado
assert task.reservation_ids.mapped('res_model') == ['project.task']
assert task._scheduling_plan_hours(4.0, datetime(2026, 5, 1, 8)) == datetime(2026, 5, 4, 18, 0)
assert task._get_reservation_date_fields() == ('planned_date_begin', 'date_end')  # enterprise
assert sorted(task._get_sync_trigger_fields()) == ['allocated_percentage', 'date_end', 'planned_date_begin', 'user_ids']
```

### MRO
```python
env['project.task'].__class__.__mro__  # incluye ResourceSchedulingMixin ✓
```

### Sample de 50 tasks random con `planned_date_begin + date_end`
Todas tienen `allocated_hours > 0` (sin regresión en el compute).

## Deuda técnica detectada (fuera de alcance — tasks separadas)
- `enterprise/spreadsheet_dashboard_mrp_account/data/dashboards.xml:4` referencia `date_finished` en `mrp.production`; el fork renombró a `date_end`. Bloquea `-u resource --test-tags /resource`.
- `enterprise/project_enterprise/tests/test_task_flow.py:102` aún usa `default_date_deadline` en context (debería ser `default_date_end`). Commit 7c25f1501b2 migró el campo pero no los context keys.
- `core/addons/project/models/project_task.py:948` — B023 lint error (loop variable binding), pre-existente.

## Artefactos

- Plan: `knowledge/agromarin-knowledge/plans/2026-04-23-t21163-align-scheduling-mixin.md`
- Research: `knowledge/agromarin-knowledge/research/2026-04-23-t20021-scheduling-architecture.md` (§8)