### PR TITLE
[FIX] web: guard params.context in executeActionButton

### DIFF
--- a/addons/web/static/src/webclient/actions/action_button_executor.js
+++ b/addons/web/static/src/webclient/actions/action_button_executor.js
@@ -168,7 +168,7 @@ export async function executeActionButton(
     //  - wrong default_* and search_default_* values won't give the expected result
     //  - wrong group_by values will fail and forbid rendering of the destination view
     const currentCtx = {};
-    for (const [key, value] of Object.entries(params.context)) {
+    for (const [key, value] of Object.entries(params.context || {})) {
         if (key.match(CTX_KEY_REGEX) === null) {
             currentCtx[key] = value;
         }


### PR DESCRIPTION
# [Task ID: 21288](https://agromarin.mx/odoo/project.task/21288)

## Problem

`UncaughtPromiseError > TypeError: Cannot convert undefined or null to object` raised at `action_button_executor.js:171` when an action button is invoked without `params.context`.

Reported on `agromarin.mx` (Accounting → Journal Items) on 2026-04-27 16:05:59 GMT.

```
TypeError: Cannot convert undefined or null to object
    at Object.entries (<anonymous>)
    at executeActionButton (web.assets_web.esm.js:25446:28565)
```

## Root cause

Regression from commit `32832886de78` (`[IMP] web: systematic JS modernization`, 2026-03-31), which migrated the loop from `for...in` to `for...of Object.entries()`:

```diff
- for (const key in params.context) {
+ for (const [key, value] of Object.entries(params.context)) {
```

`for...in` silently iterates zero times on `null`/`undefined`; `Object.entries` throws. The commit message explicitly documented the need for `|| {}` null guards on this kind of migration, but this file was missed.

## Solution

Add the `|| {}` null guard so buttons without `context` fall through cleanly, matching the pre-modernization tolerance:

```diff
- for (const [key, value] of Object.entries(params.context)) {
+ for (const [key, value] of Object.entries(params.context || {})) {
```

## Verification

- [ ] Open Accounting → Journal Items and click an action button that does not declare a `context` attribute → no TypeError
- [ ] Open any record's "Action" menu item that triggers `doActionButton` without context → no TypeError
- [ ] Existing buttons that DO pass a `context` continue to filter `default_*` / `search_default_*` / `group_by` keys correctly (`CTX_KEY_REGEX` filter still applies)