### PR TITLE
[FIX] orm: guard get_column_update against stale flat cache entries

### DIFF
--- a/odoo/orm/fields/base.py
+++ b/odoo/orm/fields/base.py
@@ -1297,6 +1297,13 @@ class Field[T]:
         # Company-dependent: collect values from all company contexts into JSONB
         values = {}
         for ctx_key, cache in field_cache.items():
+            if not isinstance(cache, dict):
+                # Skip stale flat entries (id keys → scalar values) from
+                # before field_depends_context was populated.  See the same
+                # guard in _invalidate_cache and _get_all_cache_ids — without
+                # it, scalar None values crash with `'NoneType' object has no
+                # attribute 'get'` during _load_module_terms flushes.
+                continue
             if (
                 value := cache.get(record_id, SENTINEL)
             ) is not SENTINEL and value is not PENDING:


### PR DESCRIPTION
# [Task ID: 21330](https://agromarin.mx/odoo/project.task/21330)

## Problem

The company_dependent branch of `Field.get_column_update` iterates `field_cache.items()` assuming every value is a per-context sub-dict (`{ctx_key: {record_id: value}}`).  During module setup the cache may also contain **stale flat entries** (`{record_id: scalar_value}`) left over from before `field_depends_context` was populated. Iterating over those crashes the registry with:

```
File "/opt/odoo/odoo/orm/fields/base.py", line 1301, in get_column_update
    value := cache.get(record_id, SENTINEL)
AttributeError: 'NoneType' object has no attribute 'get'
```

The crash fires inside `_load_module_terms` → `cr.flush()` → `flush_model` → `_flush` and aborts registry initialization, **blocking every PR's CI** on databases pre-loaded with custom data (`template_ci.sql` in CI, or marin190 clones locally).

## Root cause

The same hazard is already handled in three other places in this file, each of which guards with `isinstance(v, dict)` and an explanatory comment:

| Site | Guard |
|---|---|
| `_invalidate_cache` (base.py:1993) | `caches = [v for v in cache.values() if isinstance(v, dict)]` |
| `_get_all_cache_ids` (base.py:2008) | `subs = [v for v in cache.values() if isinstance(v, dict)]` |
| `get_column_update` translate-true branch (base.py:1270) | `if not isinstance(sub_cache, dict): continue` |
| **`get_column_update` company_dependent branch** | **missing** |

The comment in `_invalidate_cache:1989-1992` documents the rationale:

> During module setup, field_data may contain both per-context sub-dicts (tuple keys → dict values) AND **stale flat entries** (id keys → scalar values) from before field_depends_context was populated.  Only iterate actual sub-dicts.

The company_dependent branch was simply missing the same guard.

## Solution

Mirror the existing `isinstance(cache, dict)` guard in the company_dependent branch (3 lines plus a comment). No behaviour change for fully-populated caches; just skip stale entries instead of crashing.

```diff
  # Company-dependent: collect values from all company contexts into JSONB
  values = {}
  for ctx_key, cache in field_cache.items():
+     if not isinstance(cache, dict):
+         # Skip stale flat entries (id keys → scalar values) from
+         # before field_depends_context was populated.  See the same
+         # guard in _invalidate_cache and _get_all_cache_ids — without
+         # it, scalar None values crash with `'NoneType' object has no
+         # attribute 'get'` during _load_module_terms flushes.
+         continue
      if (
          value := cache.get(record_id, SENTINEL)
      ) is not SENTINEL and value is not PENDING:
```

## Verification

Reproduced and verified locally with a clone of `marin190` (mimicking CI's pre-loaded `template_ci.sql`):

| Scenario | Result |
|---|---|
| `-u l10n_mx_edi --test-enable` **without the fix** | ❌ `Failed to load registry` + `AttributeError: 'NoneType' object has no attribute 'get'` |
| Same command **with the fix** | ✅ `Modules loaded.` and `0 failed, 0 error(s) of 83 tests when loading database` |

```bash
$ ./core/odoo-bin -d test_repro_t21330 -u l10n_mx_edi --test-enable --stop-after-init

INFO odoo.modules.loading: Module l10n_mx_edi loaded in 5.71s, 3100 queries
INFO odoo.modules.loading: Modules loaded.
INFO odoo.tests.result: 0 failed, 0 error(s) of 83 tests when loading database 'test_repro_t21330'
```

## Related

- [t21290](https://agromarin.mx/odoo/project.task/21290) — `date_range FakeModelLoader.restore_registry` (MERGED)
- [t21297](https://agromarin.mx/odoo/project.task/21297) — `geoengine_l10n_mx` `psycopg2` (MERGED)
- [t21300](https://agromarin.mx/odoo/project.task/21300) — `l10n_mx_edi` dead `odoo.tools.zeep` patch (MERGED)
- [t18043](https://agromarin.mx/odoo/project.task/18043) — PR #659 (S3 filestore, blocked by this issue) — set as `predecessor_ids`