### PR TITLE
[IMP] project,project_hr: inline datetime + employee avatar in subtask list

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -558,7 +558,7 @@
                                     <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
                                     <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                                     <field name="company_id" column_invisible="True"/>
-                                    <field name="date_end" invisible="state in ['done', 'canceled']" optional="hide" decoration-danger="date_end and date_end &lt; current_date"/>
+                                    <field name="date_end" string="Planned Date" optional="show" readonly="state in ['done', 'canceled']" decoration-danger="date_end and date_end &lt; current_date and state not in ['done', 'canceled']"/>
                                     <field name="priority" widget="priority" optional="hide" width="70px"/>
                                     <field name="activity_ids" string="Next Activity" widget="list_activity" optional="hide"/>
                                     <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" options="{'allow_order': '1'}" optional="hide"/>

--- a/addons/project_hr/views/project_task_views.xml
+++ b/addons/project_hr/views/project_task_views.xml
@@ -23,6 +23,17 @@
                     options="{'no_open': True}"
                     domain="['|', ('company_id', '=', False), ('company_id', '=?', company_id)]" />
             </xpath>
+            <!--
+                Subtask list inside the form (child_ids O2M): swap user_ids for
+                employee_ids with the avatar widget, mirroring the main task list.
+            -->
+            <xpath expr="//field[@name='child_ids']/list//field[@name='user_ids']" position="replace">
+                <field name="user_ids" column_invisible="True" />
+                <field name="employee_ids"
+                    widget="many2many_avatar_employee"
+                    optional="show"
+                    domain="['|', ('company_id', '=', False), ('company_id', '=?', company_id)]" />
+            </xpath>
         </field>
     </record>
 
@@ -39,7 +50,7 @@
                 <field name="user_ids" column_invisible="True" />
                 <field name="employee_ids"
                     optional="show"
-                    widget="many2many_tags" />
+                    widget="many2many_avatar_employee" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
# [Task ID: 20021](https://agromarin.mx/odoo/project.task/20021)

## Problem

In the Sub-tasks tab of the project.task form:

- `user_ids` rendered with the plain user widget instead of the canonical employee avatar already used in the top-level task list.
- `date_end` was hidden by default (`optional="hide"`) and the cell was set `invisible="state in ['done','canceled']"`, hiding the planned date entirely on closed subtasks. Rescheduling a closed subtask from the parent form was impossible, and audit reads of past schedules were blocked.
- When `date_end` was past-due, `decoration-danger` painted closed subtasks in red even though the row-level `decoration-muted` already greys done/canceled rows.

## Solution

- `core/addons/project/views/project_task_views.xml:561` — `date_end` in the `child_ids` inline list:
  - `string="Planned Date"` so the column header reads "Fecha planeada" (es_MX) and matches the form's daterange label.
  - `optional="show"` (default-visible, toggleable) instead of `optional="hide"`.
  - `invisible="state in ['done','canceled']"` → `readonly="state in ['done','canceled']"` so closed rows stay visible for audit but cannot be edited.
  - `decoration-danger` scoped with `and state not in ['done','canceled']` so closed rows inherit `decoration-muted` (grey) from the list root instead of red.
- `core/addons/project_hr/views/project_task_views.xml` — new xpath on `//field[@name='child_ids']/list//field[@name='user_ids']` mirroring the top-level swap: `user_ids` → `employee_ids` with `widget="many2many_avatar_employee"`, `optional="show"`, and the multi-company domain. The existing top-level list xpath also swaps `many2many_tags` → `many2many_avatar_employee` for visual consistency.

The `date_end` column already inherits `widget="daterange"` with `start_date_field='planned_date_begin'` from `enterprise/project_enterprise/views/project_task_views.xml:80-86`, so making it visible exposes the full datetime range inline-editable.

## Verification

- `ruff check` / `ruff format --check` clean.
- `odoo-bin -c conf/agromarin190.conf -d marin190_test -u project,project_hr,project_enterprise,project_enterprise_hr --stop-after-init` loads without errors.
- `odoo-bin --test-tags '/project_enterprise_hr' -u project_enterprise_hr` — the 14 existing `TestReservationSync` tests pass; remaining failures in `test_gantt_reschedule_dates`, `test_smart_schedule`, `test_todo_mail_feature` are pre-existing FakeDatetime drift unrelated to this change.
- Manual UI review on marin190:
  - Subtask list: avatar column on assignees, "Fecha planeada" column visible by default with the daterange widget rendering start → end inline.
  - Closed subtasks render the daterange in grey (no red), readonly.
  - Open subtasks remain inline-editable.