### PR TITLE
[FIX] project: re-apply 'todo' state support in task widget

### DIFF
--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
@@ -24,6 +24,9 @@ export class ProjectTaskStateSelection extends StateSelectionField {
             isStateButtonHighlighted: false,
         });
         this.icons = {
+            // 'todo' consumed by project_workflow_step_state (step.task_state='todo').
+            // Removing breaks 1,300+ active tasks — see t19628, t21386.
+            "todo": "o_status o_status_todo",
             "in_progress": "o_status",
             "approved": "o_status o_status_green",
             "changes_requested": "fa-solid fa-exclamation-circle fa-lg",
@@ -32,6 +35,9 @@ export class ProjectTaskStateSelection extends StateSelectionField {
             "blocked": "fa-solid fa-hourglass fa-lg",
         };
         this.colorIcons = {
+            // 'todo' consumed by project_workflow_step_state (step.task_state='todo').
+            // Removing breaks 1,300+ active tasks — see t19628, t21386.
+            "todo": "",
             "in_progress": "",
             "approved": "text-success",
             "changes_requested": "o_status_changes_requested",
@@ -40,6 +46,9 @@ export class ProjectTaskStateSelection extends StateSelectionField {
             "blocked": "btn-outline-info",
         };
         this.colorButton = {
+            // 'todo' consumed by project_workflow_step_state (step.task_state='todo').
+            // Removing breaks 1,300+ active tasks — see t19628, t21386.
+            "todo": "btn-outline-info",
             "in_progress": "btn-outline-secondary",
             "approved": "btn-outline-success",
             "changes_requested": "btn-outline-warning",
@@ -83,7 +92,9 @@ export class ProjectTaskStateSelection extends StateSelectionField {
         const states = ["canceled", "done"];
         const currentState = this.props.record.data[this.props.name];
         if (currentState != "blocked") {
-            states.unshift("in_progress", "changes_requested", "approved");
+            // 'todo' consumed by project_workflow_step_state (step.task_state='todo').
+            // Removing breaks 1,300+ active tasks — see t19628, t21386.
+            states.unshift("todo", "in_progress", "changes_requested", "approved");
         }
         return states.map((state) => [state, labels.get(state)]);
     }

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.js
@@ -23,9 +23,12 @@ export class ProjectTaskStateSelection extends StateSelectionField {
         this.state = useState({
             isStateButtonHighlighted: false,
         });
+        // 'todo' is consumed by project_workflow_step_state (step.task_state='todo').
+        // Removing it from any of icons/colorIcons/colorButton or from the unshift
+        // list in get options() breaks 1,300+ active tasks — see t19628, t21386.
+        // The Hoot test in tests/project_task_state_selection.test.js asserts the
+        // dropdown still includes "To Do" — it is the primary safeguard.
         this.icons = {
-            // 'todo' consumed by project_workflow_step_state (step.task_state='todo').
-            // Removing breaks 1,300+ active tasks — see t19628, t21386.
             "todo": "o_status o_status_todo",
             "in_progress": "o_status",
             "approved": "o_status o_status_green",
@@ -35,8 +38,6 @@ export class ProjectTaskStateSelection extends StateSelectionField {
             "blocked": "fa-solid fa-hourglass fa-lg",
         };
         this.colorIcons = {
-            // 'todo' consumed by project_workflow_step_state (step.task_state='todo').
-            // Removing breaks 1,300+ active tasks — see t19628, t21386.
             "todo": "",
             "in_progress": "",
             "approved": "text-success",
@@ -46,8 +47,6 @@ export class ProjectTaskStateSelection extends StateSelectionField {
             "blocked": "btn-outline-info",
         };
         this.colorButton = {
-            // 'todo' consumed by project_workflow_step_state (step.task_state='todo').
-            // Removing breaks 1,300+ active tasks — see t19628, t21386.
             "todo": "btn-outline-info",
             "in_progress": "btn-outline-secondary",
             "approved": "btn-outline-success",
@@ -92,8 +91,6 @@ export class ProjectTaskStateSelection extends StateSelectionField {
         const states = ["canceled", "done"];
         const currentState = this.props.record.data[this.props.name];
         if (currentState != "blocked") {
-            // 'todo' consumed by project_workflow_step_state (step.task_state='todo').
-            // Removing breaks 1,300+ active tasks — see t19628, t21386.
             states.unshift("todo", "in_progress", "changes_requested", "approved");
         }
         return states.map((state) => [state, labels.get(state)]);

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.scss
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.scss
@@ -38,6 +38,10 @@
     .o_status_changes_requested {
         color: $warning;
     }
+
+    .o_status_todo {
+        background-color: map-get($theme-colors, "info");
+    }
 }
 
 .project_task_state_selection_menu {
@@ -57,6 +61,10 @@
 
     .o_status_changes_requested {
         color: $warning;
+    }
+
+    .o_status_todo {
+        background-color: map-get($theme-colors, "info");
     }
 }
 

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
@@ -42,9 +42,7 @@
                                     Mark as done
                                 </span>
                             </t>
-                            <t t-else="">
-                                <t t-out="label"/>
-                            </t>
+                            <t t-else="" t-out="label"/>
                         </span>
                     </div>
                 </button>

--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
@@ -20,7 +20,7 @@
         </xpath>
         <!-- The toggle mark as done button -->
         <xpath expr="//t[@t-if='props.readonly']" position="after">
-            <t t-elif="isToggleMode and currentValue == 'in_progress'">
+            <t t-elif="isToggleMode and ['todo', 'in_progress'].includes(currentValue)">
                 <button t-if="isView(['activity', 'kanban', 'list', 'calendar']) or this.env.isSmall"
                         class="d-flex align-items-center btn fw-normal p-0"
                         tabindex="-1"
@@ -42,8 +42,8 @@
                                     Mark as done
                                 </span>
                             </t>
-                            <t t-else="currentValue == 'in_progress'">
-                                In Progress
+                            <t t-else="">
+                                <t t-out="label"/>
                             </t>
                         </span>
                     </div>

--- a/addons/project/static/tests/project_task_state_selection.test.js
+++ b/addons/project/static/tests/project_task_state_selection.test.js
@@ -63,6 +63,7 @@ test("project.task (form): check task state widget", async () => {
     await click("button.o_state_button");
     await animationFrame();
     expect(queryAllTexts(".state_selection_field_menu > .dropdown-item")).toEqual([
+        "To Do",
         "In Progress",
         "Changes Requested",
         "Approved",


### PR DESCRIPTION
# [Task ID: 21386](https://agromarin.mx/odoo/project.task/21386)

## Problem
El widget `project_task_state_selection` perdió por segunda vez el soporte para el estado `todo`. Commit `e100ce3407da` (t20080) sobrescribió el re-apply original `5b442042611b` (t19628). En marin190 hay 1,359 tareas activas con `state='todo'` que renderizan sin label/color/toggle correctos.

El modelo Python ya soporta `todo` (`core/addons/project/models/project_task.py:282-301`) y el addon `project_workflow_step_state` lo consume (`step.task_state='todo'` en steps Backlog/Por Hacer). Lo que faltaba en el widget JS/XML/SCSS son los mapeos visuales y la inclusión en el dropdown.

## Evidence

<img width="586" height="459" alt="Captura desde 2026-04-29 13-43-15" src="https://github.com/user-attachments/assets/ecde50c2-73b8-4f58-bf7f-35861899fdd5" />

## Solution
- **JS**: agregar `'todo'` a `icons` (`o_status o_status_todo`), `colorIcons` (`""`), `colorButton` (`btn-outline-info`), y `unshift` en `get options()`.
- **XML**: ampliar el `t-elif` de toggle a `['todo','in_progress'].includes(currentValue)`; reemplazar el texto hardcodeado `"In Progress"` por `<t t-out="label"/>` para que el pill muestre el label correcto.
- **SCSS**: agregar `.o_status_todo { background-color: map-get($theme-colors, "info") }` en los 2 scopes (toggler + dropdown menu).
- **Test Hoot**: el assertion del dropdown ahora incluye `"To Do"` — bloquea futuras pérdidas en CI.
- **Centinelas**: comentarios cerca de cada entrada `todo` (3 dicts + unshift) advirtiendo del impacto en `project_workflow_step_state`.

## Verification
- `./addons/core/odoo-bin -c ./conf/agromarin190.conf -d marin190 -u project --stop-after-init --workers=0` → carga limpia.
- Verificación visual en marin190: bubble azul info en form/kanban/list/activity, dropdown con `To Do` como primera opción, toggle directo `todo → done` funcional, sin regresiones en `in_progress`/`approved`/`done`/`canceled`/`blocked`.
- Test Hoot actualizado en `static/tests/project_task_state_selection.test.js`.

## Out of scope
- Migración FA5→FA7 de iconos (`fa-exclamation-circle` → `fa-circle-exclamation`) — se separa en tarea aparte.