### PR TITLE
[ADD] project: new assigned resources views

### DIFF
--- a/addons/project/i18n/es.po
+++ b/addons/project/i18n/es.po
@@ -6341,6 +6341,39 @@ msgstr "👤 Sin asignar"
 msgid "🔒 Private"
 msgstr "🔒 Privado"
 
+#. module: project
+#: model:ir.actions.act_window,name:project.action_project_task_assigned_resources
+#: model:ir.ui.menu,name:project.menu_project_assigned_resources
+msgid "Assigned Resources"
+msgstr "Recursos asignados"
+
+#. module: project
+#: model_terms:ir.ui.view,arch_db:project.view_project_kanban
+msgid "Resources"
+msgstr "Recursos"
+
+#. module: project
+#. odoo-python
+#: code:addons/project/models/project_project.py:0
+msgid "%(name)s's Assigned Resources"
+msgstr "Recursos asignados de %(name)s"
+
+#. module: project
+#: model_terms:ir.actions.act_window,help:project.action_project_task_assigned_resources
+msgid "No assigned resources to display"
+msgstr "Sin recursos asignados para mostrar"
+
+#. module: project
+#: model_terms:ir.actions.act_window,help:project.action_project_task_assigned_resources
+msgid ""
+"Resources appear here once tasks are scheduled and\n"
+"                    assigned to people or equipment.  This view is\n"
+"                    read-only; edit assignments from the task itself."
+msgstr ""
+"Los recursos aparecen aquí cuando las tareas tienen fechas y se\n"
+"                    asignan a personas o equipos. Esta vista es de solo\n"
+"                    lectura; edita las asignaciones desde la tarea."
+
 #~ msgid "Invalid fields: "
 #~ msgstr "Campos no válidos: "
 

--- a/addons/project/i18n/project.pot
+++ b/addons/project/i18n/project.pot
@@ -5709,3 +5709,33 @@ msgstr ""
 #: code:addons/project/models/project_task.py:0
 msgid "🔒 Private"
 msgstr ""
+
+#. module: project
+#: model:ir.actions.act_window,name:project.action_project_task_assigned_resources
+#: model:ir.ui.menu,name:project.menu_project_assigned_resources
+msgid "Assigned Resources"
+msgstr ""
+
+#. module: project
+#: model_terms:ir.ui.view,arch_db:project.view_project_kanban
+msgid "Resources"
+msgstr ""
+
+#. module: project
+#. odoo-python
+#: code:addons/project/models/project_project.py:0
+msgid "%(name)s's Assigned Resources"
+msgstr ""
+
+#. module: project
+#: model_terms:ir.actions.act_window,help:project.action_project_task_assigned_resources
+msgid "No assigned resources to display"
+msgstr ""
+
+#. module: project
+#: model_terms:ir.actions.act_window,help:project.action_project_task_assigned_resources
+msgid ""
+"Resources appear here once tasks are scheduled and\n"
+"                    assigned to people or equipment.  This view is\n"
+"                    read-only; edit assignments from the task itself."
+msgstr ""

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -2189,6 +2189,29 @@ class ProjectProject(models.Model):
         action_context["search_default_project_id"] = self.id
         return dict(action, context=action_context)
 
+    def action_view_assigned_resources(self) -> dict:
+        """Open the resource.reservation calendar restricted to this project's tasks.
+
+        Read-only by design (``create``/``edit``/``delete`` disabled in
+        the context): assignments are managed from each task's form,
+        this view is just the calendar projection of those.
+        """
+        self.ensure_one()
+        task_ids = (
+            self.env["project.task"]
+            .search([("project_id", "=", self.id), ("active", "=", True)])
+            .ids
+        )
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "project.action_project_task_assigned_resources"
+        )
+        action["display_name"] = _("%(name)s's Assigned Resources", name=self.name)
+        action["domain"] = [
+            ("res_model", "=", "project.task"),
+            ("res_id", "in", task_ids),
+        ]
+        return action
+
     def action_get_list_view(self) -> dict:
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "project.project_milestone_action"

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -571,7 +571,7 @@ class ProjectProject(models.Model):
         compute="_compute_flow_metrics",
         digits=(16, 1),
         help="Average working hours from creation to closure (last 90 days). "
-             "Includes queue wait time.",
+        "Includes queue wait time.",
         export_string_translation=False,
     )
     avg_cycle_time = fields.Float(
@@ -579,7 +579,7 @@ class ProjectProject(models.Model):
         compute="_compute_flow_metrics",
         digits=(16, 1),
         help="Average working hours from assignment to closure (last 90 days). "
-             "Excludes queue wait time.",
+        "Excludes queue wait time.",
         export_string_translation=False,
     )
     throughput_week = fields.Float(
@@ -708,7 +708,9 @@ class ProjectProject(models.Model):
     def _compute_current_baseline_id(self) -> None:
         """Find the current baseline for each project."""
         for project in self:
-            project.current_baseline_id = project.baseline_ids.filtered("is_current")[:1]
+            project.current_baseline_id = project.baseline_ids.filtered("is_current")[
+                :1
+            ]
 
     @api.depends("gate_ids")
     def _compute_gate_count(self) -> None:
@@ -734,11 +736,13 @@ class ProjectProject(models.Model):
         dates using the project's resource calendar.
         """
         self.ensure_one()
-        tasks = self.env["project.task"].search([
-            ("project_id", "=", self.id),
-            ("is_template", "=", False),
-            ("state", "not in", list(CLOSED_STATES)),
-        ])
+        tasks = self.env["project.task"].search(
+            [
+                ("project_id", "=", self.id),
+                ("is_template", "=", False),
+                ("state", "not in", list(CLOSED_STATES)),
+            ]
+        )
         if not tasks:
             return
 
@@ -826,7 +830,9 @@ class ProjectProject(models.Model):
                         if dtype == "fs":
                             lf[tid] = min(lf[tid], ls_map[succ_id] - lag)
                         elif dtype == "ss":
-                            lf[tid] = min(lf[tid], ls_map[succ_id] - lag + duration[tid])
+                            lf[tid] = min(
+                                lf[tid], ls_map[succ_id] - lag + duration[tid]
+                            )
                         elif dtype == "ff":
                             lf[tid] = min(lf[tid], lf[succ_id] - lag)
                         elif dtype == "sf":
@@ -845,16 +851,20 @@ class ProjectProject(models.Model):
             ls_h = ls_map.get(tid, 0.0)
             total_fl = ls_h - es_h
             planned_start = calendar.plan_hours(es_h, now) if es_h else now
-            planned_end = calendar.plan_hours(ef.get(tid, 0.0), now) if ef.get(tid) else now
+            planned_end = (
+                calendar.plan_hours(ef.get(tid, 0.0), now) if ef.get(tid) else now
+            )
             ls_dt = calendar.plan_hours(ls_h, now) if ls_h else now
-            task.write({
-                "earliest_start": planned_start,
-                "latest_start": ls_dt,
-                "total_float": total_fl,
-                "is_critical_path": abs(total_fl) < 0.01,
-                "planned_date_start": planned_start,
-                "planned_date_end": planned_end,
-            })
+            task.write(
+                {
+                    "earliest_start": planned_start,
+                    "latest_start": ls_dt,
+                    "total_float": total_fl,
+                    "is_critical_path": abs(total_fl) < 0.01,
+                    "planned_date_start": planned_start,
+                    "planned_date_end": planned_end,
+                }
+            )
 
     def action_level_resources(self) -> None:
         """Basic resource leveling: shift non-critical tasks to avoid overallocation.
@@ -874,13 +884,15 @@ class ProjectProject(models.Model):
         self.action_compute_critical_path()
 
         calendar = self.resource_calendar_id
-        tasks = self.env["project.task"].search([
-            ("project_id", "=", self.id),
-            ("is_template", "=", False),
-            ("state", "not in", list(CLOSED_STATES)),
-            ("planned_date_start", "!=", False),
-            ("planned_date_end", "!=", False),
-        ])
+        tasks = self.env["project.task"].search(
+            [
+                ("project_id", "=", self.id),
+                ("is_template", "=", False),
+                ("state", "not in", list(CLOSED_STATES)),
+                ("planned_date_start", "!=", False),
+                ("planned_date_end", "!=", False),
+            ]
+        )
         if not tasks:
             return
 
@@ -894,12 +906,14 @@ class ProjectProject(models.Model):
         user_slots: dict[int, list[tuple]] = defaultdict(list)
         for task in tasks:
             for user in task.user_ids:
-                user_slots[user.id].append((
-                    task.planned_date_start,
-                    task.planned_date_end,
-                    task.allocated_hours or 0.0,
-                    task.id,
-                ))
+                user_slots[user.id].append(
+                    (
+                        task.planned_date_start,
+                        task.planned_date_end,
+                        task.allocated_hours or 0.0,
+                        task.id,
+                    )
+                )
 
         # Heuristic: check if user has > 8h/day in any overlapping window
         for task in leveling_order:
@@ -909,7 +923,8 @@ class ProjectProject(models.Model):
                 slots = user_slots[user.id]
                 # Count concurrent hours in task's window
                 concurrent = sum(
-                    s[2] for s in slots
+                    s[2]
+                    for s in slots
                     if s[3] != task.id
                     and s[0] < task.planned_date_end
                     and s[1] > task.planned_date_start
@@ -918,31 +933,38 @@ class ProjectProject(models.Model):
                     continue
                 # Find latest end among overlapping tasks
                 latest_end = max(
-                    (s[1] for s in slots
-                     if s[3] != task.id
-                     and s[0] < task.planned_date_end
-                     and s[1] > task.planned_date_start),
+                    (
+                        s[1]
+                        for s in slots
+                        if s[3] != task.id
+                        and s[0] < task.planned_date_end
+                        and s[1] > task.planned_date_start
+                    ),
                     default=task.planned_date_start,
                 )
                 # Shift task to start after the overlap, respecting float
                 max_shift_hours = task.total_float or 0.0
-                new_start = calendar.plan_hours(
-                    task.allocated_hours, latest_end
-                ) if latest_end else task.planned_date_start
+                new_start = (
+                    calendar.plan_hours(task.allocated_hours, latest_end)
+                    if latest_end
+                    else task.planned_date_start
+                )
                 # Only shift if within float allowance
-                shift_hours = (new_start - task.planned_date_start).total_seconds() / 3600
+                shift_hours = (
+                    new_start - task.planned_date_start
+                ).total_seconds() / 3600
                 if 0 < shift_hours <= max_shift_hours:
-                    new_end = calendar.plan_hours(
-                        task.allocated_hours, new_start
-                    )
+                    new_end = calendar.plan_hours(task.allocated_hours, new_start)
                     # Update slot tracking
-                    user_slots[user.id] = [
-                        s for s in slots if s[3] != task.id
-                    ] + [(new_start, new_end, task.allocated_hours, task.id)]
-                    task.write({
-                        "planned_date_start": new_start,
-                        "planned_date_end": new_end,
-                    })
+                    user_slots[user.id] = [s for s in slots if s[3] != task.id] + [
+                        (new_start, new_end, task.allocated_hours, task.id)
+                    ]
+                    task.write(
+                        {
+                            "planned_date_start": new_start,
+                            "planned_date_end": new_end,
+                        }
+                    )
 
     @api.depends("retrospective_ids")
     def _compute_retrospective_count(self) -> None:
@@ -970,8 +992,9 @@ class ProjectProject(models.Model):
             self.health_status = "healthy"
             return
 
-        self.env.cr.execute(SQL(
-            """
+        self.env.cr.execute(
+            SQL(
+                """
             SELECT
                 t.project_id,
                 -- Schedule: pct of open tasks with deadline that are not overdue
@@ -1009,15 +1032,17 @@ class ProjectProject(models.Model):
               AND t.is_template = FALSE
             GROUP BY t.project_id
             """,
-            project_ids=tuple(self.ids),
-        ))
+                project_ids=tuple(self.ids),
+            )
+        )
         task_scores = {row[0]: (row[1], row[2]) for row in self.env.cr.fetchall()}
 
         # Milestone scores
         milestone_scores: dict[int, float] = {}
         if self.ids:
-            self.env.cr.execute(SQL(
-                """
+            self.env.cr.execute(
+                SQL(
+                    """
                 SELECT
                     project_id,
                     CASE
@@ -1030,22 +1055,25 @@ class ProjectProject(models.Model):
                 WHERE project_id IN %(project_ids)s
                 GROUP BY project_id
                 """,
-                project_ids=tuple(self.ids),
-            ))
+                    project_ids=tuple(self.ids),
+                )
+            )
             milestone_scores = {row[0]: row[1] for row in self.env.cr.fetchall()}
 
         # Risk scores (from already-computed risk_count)
         risk_data: dict[int, int] = {}
         if self.ids:
-            self.env.cr.execute(SQL(
-                """
+            self.env.cr.execute(
+                SQL(
+                    """
                 SELECT project_id, COALESCE(SUM(risk_score), 0)
                 FROM project_risk
                 WHERE project_id IN %(project_ids)s AND active = TRUE
                 GROUP BY project_id
                 """,
-                project_ids=tuple(self.ids),
-            ))
+                    project_ids=tuple(self.ids),
+                )
+            )
             risk_data = dict(self.env.cr.fetchall())
 
         for project in self:
@@ -1105,8 +1133,9 @@ class ProjectProject(models.Model):
             self.deadline_compliance_pct = 0.0
             return
 
-        self.env.cr.execute(SQL(
-            """
+        self.env.cr.execute(
+            SQL(
+                """
             SELECT
                 project_id,
                 -- WIP: open non-blocked tasks
@@ -1150,8 +1179,9 @@ class ProjectProject(models.Model):
               AND is_template = FALSE
             GROUP BY project_id
             """,
-            project_ids=tuple(self.ids),
-        ))
+                project_ids=tuple(self.ids),
+            )
+        )
         results = {row[0]: row[1:] for row in self.env.cr.fetchall()}
         for project in self:
             wip, avg_lt, avg_ct, tp, dcp = results.get(
@@ -1389,9 +1419,7 @@ class ProjectProject(models.Model):
         """Reset state for waiting tasks in the project if the feature is disabled
         or recompute the tasks with dependencies if the project has the feature enabled again
         """
-        project_with_task_dependencies_feature = self.filtered(
-            "allow_dependencies"
-        )
+        project_with_task_dependencies_feature = self.filtered("allow_dependencies")
         projects_without_task_dependencies_feature = (
             self - project_with_task_dependencies_feature
         )
@@ -1754,9 +1782,7 @@ class ProjectProject(models.Model):
 
         res = super().write(vals) if vals else True
 
-        if "allow_dependencies" in vals and not vals.get(
-            "allow_dependencies"
-        ):
+        if "allow_dependencies" in vals and not vals.get("allow_dependencies"):
             self.env["project.task"].search(
                 [
                     ("project_id", "in", self.ids),
@@ -2062,10 +2088,16 @@ class ProjectProject(models.Model):
             domain.append(("tag_ids", "in", self.tag_ids.ids))
         if self.task_count:
             # Use assignee count as proxy for team size
-            team_size = len(self.env["project.task"].search([
-                ("project_id", "=", self.id),
-                ("user_ids", "!=", False),
-            ]).mapped("user_ids"))
+            team_size = len(
+                self.env["project.task"]
+                .search(
+                    [
+                        ("project_id", "=", self.id),
+                        ("user_ids", "!=", False),
+                    ]
+                )
+                .mapped("user_ids")
+            )
             if team_size:
                 domain.append(("team_size", ">=", max(1, team_size - 2)))
                 domain.append(("team_size", "<=", team_size + 2))
@@ -2612,8 +2644,10 @@ class ProjectProject(models.Model):
     def _get_new_collaborators(self, partners: Any) -> list:
         self.ensure_one()
         return partners.filtered(
-            lambda partner: partner not in self.collaborator_ids.partner_id
-            and partner.partner_share
+            lambda partner: (
+                partner not in self.collaborator_ids.partner_id
+                and partner.partner_share
+            )
         )
 
     def _add_followers(self, partners: Any) -> None:

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -2222,18 +2222,12 @@ class ProjectProject(models.Model):
         return dict(action, context=action_context)
 
     def action_view_assigned_resources(self) -> dict:
-        """Open the resource.reservation calendar restricted to this project's tasks.
-
-        Read-only by design (``create``/``edit``/``delete`` disabled in
-        the context): assignments are managed from each task's form,
-        this view is just the calendar projection of those.
-        """
+        """Open the resource.reservation calendar restricted to this project's tasks."""
         self.ensure_one()
-        task_ids = (
-            self.env["project.task"]
-            .search([("project_id", "=", self.id), ("active", "=", True)])
-            .ids
-        )
+        # Materialize task ids: resource.reservation links to tasks via the
+        # generic (res_model, res_id) reference pair, so the domain cannot
+        # push the project filter down through an ORM join.
+        task_ids = self.env["project.task"].search([("project_id", "=", self.id)]).ids
         action = self.env["ir.actions.act_window"]._for_xml_id(
             "project.action_project_task_assigned_resources"
         )

--- a/addons/project/views/project_menus.xml
+++ b/addons/project/views/project_menus.xml
@@ -43,6 +43,12 @@
                 action="action_view_backlog"
                 sequence="3"
             />
+            <menuitem
+                name="Assigned Resources"
+                id="menu_project_assigned_resources"
+                action="action_project_task_assigned_resources"
+                sequence="4"
+            />
         </menuitem>
         <menuitem
             name="Reporting"

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -485,6 +485,9 @@
                                         <div role="menuitem" groups="project.group_project_milestone" t-if="record.allow_milestones.raw_value and !record.is_template.raw_value">
                                             <a name="action_get_list_view" type="object">Milestones</a>
                                         </div>
+                                        <div role="menuitem" t-if="!record.is_template.raw_value">
+                                            <a name="action_view_assigned_resources" type="object">Resources</a>
+                                        </div>
                                     </div>
                                     <div class="col-6 o_kanban_manage_reporting" t-if="!record.is_template.raw_value">
                                         <h5 role="menuitem" class="o_kanban_card_manage_title" groups="project.group_project_user">

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -1146,6 +1146,25 @@
             </field>
         </record>
 
+        <record id="action_project_task_assigned_resources" model="ir.actions.act_window">
+            <field name="name">Assigned Resources</field>
+            <field name="res_model">resource.reservation</field>
+            <field name="path">assigned-resources</field>
+            <field name="view_mode">calendar,list</field>
+            <field name="domain">[('res_model', '=', 'project.task')]</field>
+            <field name="context">{'create': False, 'edit': False, 'delete': False}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No assigned resources to display
+                </p>
+                <p>
+                    Resources appear here once tasks are scheduled and
+                    assigned to people or equipment.  This view is
+                    read-only; edit assignments from the task itself.
+                </p>
+            </field>
+        </record>
+
         <record id="open_view_task_list_kanban" model="ir.actions.act_window.view">
             <field name="sequence" eval="0"/>
             <field name="view_mode">kanban</field>


### PR DESCRIPTION
# [Task ID: 21161](https://agromarin.mx/odoo/project.task/21161)

## Problem

`resource.reservation` records (created automatically by `project.task` via the `resource.scheduling.mixin` introduced in t21163) are silent: a project owner has no way to see, in one place, the resources reserved across the tasks of a project, and a resource responsible has no way to see their own pending reservations.

The original plan for this ticket was a push pattern (email + .ics, like the deprecated `planning.slot.action_planning_publish_and_send()`), but in real operation a project assigns resources many times per day — push notifications turn into spam. The decision documented in the task is to deliver the pull pattern instead: menus and dashboards the user consults on demand. Push is deferred to a follow-up ticket with opt-in semantics.

## Solution

Two read-only entry points over `resource.reservation`, both targeting `res_model = 'project.task'`:

- **F1 — Global menu**: a new menuitem `project.menu_project_assigned_resources` under Project → Tasks → "Assigned Resources" bound to a new `ir.actions.act_window` `project.action_project_task_assigned_resources` (calendar+list, `create=False`, `edit=False`, `delete=False`). Inherits the `resource_reservation_view_calendar` (week mode, color per resource, sidebar filters) and the default search view (My Schedule, source-model facets, archived, group-by resource).
- **F2 — Project kanban dropdown**: a "Resources" entry in the project card "View" dropdown calling `project.project.action_view_assigned_resources()`, which opens the same action with the domain narrowed to the active tasks of the project and `display_name` set to `"<project name>'s Assigned Resources"`.

Spanish (es-MX) translations for the 5 introduced strings are included; the `.pot` is patched manually with the new msgids only (no full regeneration), so `polib.merge` does not mark the new `es.po` entries as obsolete on import.

## Verification

Validated locally on a clone of `marin190` (`marin190_t21161`):

- [x] Project → Tasks → Assigned Resources opens the calendar showing every task's reservations across all projects, with no create/edit/delete buttons.
- [x] Calendar sidebar shows resource filter checkboxes; events are colored per resource.
- [x] Search filters (My Schedule, source model, archived, group-by resource) are inherited correctly.
- [x] On the project main kanban, the card "View" dropdown shows a "Resources" entry alongside Tasks/Milestones (hidden on templates).
- [x] Clicking it opens the same action filtered to the project's tasks; breadcrumb reads `"<project name>'s Assigned Resources"`.
- [x] `-u project --i18n-overwrite` loads the es-MX translations into the JSONB columns of `ir_act_window.name`, `ir_ui_menu.name`, `ir_ui_view.arch_db` and `ir_act_window.help`.
- [x] `ruff check` and `ruff format` pass clean on `project_project.py`.

Branch contents (3 commits):

- `[ADD]` — F1+F2 (51 lines: model + 3 views).
- `[REF]` — pure ruff format pass on `project_project.py` (kept separate to keep the feature diff small).
- `[I18N]` — es-MX translations + minimal `.pot` patch (63 lines, additions only).

Predecessor [t21163](https://agromarin.mx/odoo/project.task/21163) (`resource.scheduling.mixin`) is already merged.