### PR TITLE
[ADD] project: PMI hours separation in project.task

### DIFF
--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -15,12 +15,12 @@ PROJECT_TASK_READABLE_FIELDS = {
     'analytic_account_active',
     'effective_hours',
     'encode_uom_in_days',
-    'allocated_hours',
+    'planned_hours',
     'progress',
     'overtime',
     'remaining_hours',
     'subtask_effective_hours',
-    'subtask_allocated_hours',
+    'subtask_planned_hours',
     'timesheet_ids',
     'total_hours_spent',
 }
@@ -36,7 +36,7 @@ class ProjectTask(models.Model):
         "Allow timesheets",
         compute='_compute_allow_timesheets', search='_search_allow_timesheets',
         compute_sudo=True, readonly=True, export_string_translation=False)
-    remaining_hours = fields.Float("Time Remaining", compute='_compute_remaining_hours', store=True, readonly=True, help="Number of allocated hours minus the number of hours spent.")
+    remaining_hours = fields.Float("Time Remaining", compute='_compute_remaining_hours', store=True, readonly=True, help="Number of planned hours minus the number of hours spent.")
     remaining_hours_percentage = fields.Float(compute='_compute_remaining_hours_percentage', search='_search_remaining_hours_percentage', export_string_translation=False)
     effective_hours = fields.Float("Time Spent", compute='_compute_effective_hours', compute_sudo=True, store=True)
     total_hours_spent = fields.Float("Total Time Spent", compute='_compute_total_hours_spent', store=True, help="Time spent on this task and its sub-tasks (and their own sub-tasks).")
@@ -46,7 +46,7 @@ class ProjectTask(models.Model):
     timesheet_ids = fields.One2many('account.analytic.line', 'task_id', 'Timesheets', export_string_translation=False)
     encode_uom_in_days = fields.Boolean(compute='_compute_encode_uom_in_days', default=lambda self: self._uom_in_days(), export_string_translation=False)
     display_name = fields.Char(help="""Use these keywords in the title to set new tasks:\n
-        30h Allocate 30 hours to the task
+        30h Plan 30 hours for the task
         #tags Set tags on the task
         @user Assign the task to a user
         ! Set the task a medium priority
@@ -92,22 +92,22 @@ class ProjectTask(models.Model):
         for task in self:
             task.effective_hours = timesheets_per_task.get(task.id, 0.0)
 
-    @api.depends('effective_hours', 'subtask_effective_hours', 'allocated_hours')
+    @api.depends('effective_hours', 'subtask_effective_hours', 'planned_hours')
     def _compute_progress_hours(self):
         for task in self:
-            if (task.allocated_hours > 0.0):
+            if (task.planned_hours > 0.0):
                 task_total_hours = task.effective_hours + task.subtask_effective_hours
-                task.overtime = max(task_total_hours - task.allocated_hours, 0)
-                task.progress = round(task_total_hours / task.allocated_hours, 2)
+                task.overtime = max(task_total_hours - task.planned_hours, 0)
+                task.progress = round(task_total_hours / task.planned_hours, 2)
             else:
                 task.progress = 0.0
                 task.overtime = 0
 
-    @api.depends('allocated_hours', 'remaining_hours')
+    @api.depends('planned_hours', 'remaining_hours')
     def _compute_remaining_hours_percentage(self):
         for task in self:
-            if task.allocated_hours > 0.0:
-                task.remaining_hours_percentage = task.remaining_hours / task.allocated_hours
+            if task.planned_hours > 0.0:
+                task.remaining_hours_percentage = task.remaining_hours / task.planned_hours
             else:
                 task.remaining_hours_percentage = 0.0
 
@@ -120,18 +120,18 @@ class ProjectTask(models.Model):
             SELECT id
               FROM %s
              WHERE remaining_hours > 0
-               AND allocated_hours > 0
-               AND remaining_hours / allocated_hours %s %s
+               AND planned_hours > 0
+               AND remaining_hours / planned_hours %s %s
         )""", SQL.identifier(self._table), SQL(operator), value)
         return [('id', 'in', sql)]
 
-    @api.depends('effective_hours', 'subtask_effective_hours', 'allocated_hours')
+    @api.depends('effective_hours', 'subtask_effective_hours', 'planned_hours')
     def _compute_remaining_hours(self):
         for task in self:
-            if not task.allocated_hours:
+            if not task.planned_hours:
                 task.remaining_hours = 0.0
             else:
-                task.remaining_hours = task.allocated_hours - task.effective_hours - task.subtask_effective_hours
+                task.remaining_hours = task.planned_hours - task.effective_hours - task.subtask_effective_hours
 
     @api.depends('effective_hours', 'subtask_effective_hours')
     def _compute_total_hours_spent(self):
@@ -146,23 +146,23 @@ class ProjectTask(models.Model):
     def _get_group_pattern(self):
         return {
             **super()._get_group_pattern(),
-            'allocated_hours': r'\s(\d+(?:\.\d+)?)[hH]',
+            'planned_hours': r'\s(\d+(?:\.\d+)?)[hH]',
         }
 
     def _prepare_pattern_groups(self):
-        return [self._get_group_pattern()['allocated_hours']] + super()._prepare_pattern_groups()
+        return [self._get_group_pattern()['planned_hours']] + super()._prepare_pattern_groups()
 
     def _get_cannot_start_with_patterns(self):
         return super()._get_cannot_start_with_patterns() + [r'(?!\d+(?:\.\d+)?(?:h|H))']
 
-    def _extract_allocated_hours(self):
-        allocated_hours_group = self._get_group_pattern()['allocated_hours']
+    def _extract_planned_hours(self):
+        planned_hours_group = self._get_group_pattern()['planned_hours']
         if self.allow_timesheets:
-            self.allocated_hours = sum(float(num) for num in re.findall(allocated_hours_group, self.display_name))
-            self.display_name, dummy = re.subn(allocated_hours_group, '', self.display_name)
+            self.planned_hours = sum(float(num) for num in re.findall(planned_hours_group, self.display_name))
+            self.display_name, dummy = re.subn(planned_hours_group, '', self.display_name)
 
     def _get_groups(self):
-        return [lambda task: task._extract_allocated_hours()] + super()._get_groups()
+        return [lambda task: task._extract_planned_hours()] + super()._get_groups()
 
     def action_view_subtask_timesheet(self):
         self.ensure_one()

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -32,10 +32,10 @@
                 <field name="encode_uom_in_days" invisible="1"/>
                 <field name="subtask_count" invisible="1"/>
                 <label for="allocated_hours" invisible="not allow_timesheets"/>
-                <div id="allocated_hours_container" class="text-nowrap" invisible="not allow_timesheets">
-                    <field name="allocated_hours" class="oe_inline" widget="float_time" readonly="1"/>
+                <div id="planned_hours_container" class="text-nowrap" invisible="not allow_timesheets">
+                    <field name="planned_hours" class="oe_inline" widget="float_time" readonly="1"/>
                     <span invisible="subtask_count == 0">
-                        (incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
+                        (incl. <field name="subtask_planned_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
                         <span class="fw-bold text-dark"> Sub-tasks</span>)
                     </span>
                     (<field name="progress" invisible="not project_id" class="oe_inline" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>)

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -19,10 +19,10 @@
                     <field name="encode_uom_in_days" invisible="1"/>
                     <field name="subtask_count" invisible="1"/>
                     <label for="allocated_hours" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>
-                    <div id="allocated_hours_container" class="text-nowrap" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
-                        <field name="allocated_hours" class="oe_inline o_field_float_time o_task_planned_hours" widget="timesheet_uom_no_toggle"/>
+                    <div id="planned_hours_container" class="text-nowrap" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
+                        <field name="planned_hours" class="oe_inline o_field_float_time o_task_planned_hours" widget="timesheet_uom_no_toggle"/>
                         <span invisible="subtask_count == 0">
-                            (incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
+                            (incl. <field name="subtask_planned_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
                             <span class="fw-bold text-dark"> Sub-tasks</span>)
                         </span>
                          <span invisible="is_template or has_project_template">

--- a/addons/project/__manifest__.py
+++ b/addons/project/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Project",
-    "version": "1.6",
+    "version": "1.7",
     "website": "https://www.odoo.com/app/project",
     "category": "Services/Project",
     "sequence": 45,

--- a/addons/project/migrations/1.7/post-migrate.py
+++ b/addons/project/migrations/1.7/post-migrate.py
@@ -1,0 +1,115 @@
+"""Recompute PMI fields on every project.task (t20171).
+
+The three new stored compute fields (``scheduled_hours``,
+``planned_hours``, ``allocation_state``) are added empty by the
+pre-migrate.  Stored compute fields stay at their initial value until
+a dependency write triggers recompute, so a same-version reinstall or
+a migration that does not touch dependencies would leave existing
+records at zero.
+
+This post-migrate forces a fresh recompute of all three fields on
+every active task (with or without dates):
+
+- Tasks with ``planned_date_begin`` + ``date_end``: ``scheduled_hours``
+  is recomputed against the company calendar; ``planned_hours`` and
+  ``allocation_state`` cascade through the ``@api.depends`` chain.
+- Tasks without dates: ``scheduled_hours = 0`` →
+  ``planned_hours = 0`` → ``allocation_state = unestimated``.  Honest
+  representation; no legacy seeding.
+
+Tracking is disabled to avoid generating ``mail.tracking.value`` rows
+on the bulk recompute.
+"""
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # Backfill company_id where NULL.  The PMI compute resolves the
+    # calendar via task.company_id (then env.company as last resort).
+    # Without explicit company_id the result depends on the user who
+    # triggers the recompute -- non-deterministic.  Resolution chain:
+    # 1. project.company_id  (canonical Odoo default for project.task)
+    # 2. create_uid.company_id  (the user who created it implicitly chose
+    #    this company; matches what would have been picked at create time)
+    # 3. lowest-id assignee.company_id  (deterministic when no create_uid)
+    cr.execute(
+        """
+        UPDATE project_task pt
+           SET company_id = p.company_id
+          FROM project_project p
+         WHERE pt.project_id = p.id
+           AND pt.company_id IS NULL
+           AND p.company_id IS NOT NULL
+        """
+    )
+    from_project = cr.rowcount
+
+    cr.execute(
+        """
+        UPDATE project_task pt
+           SET company_id = u.company_id
+          FROM res_users u
+         WHERE pt.create_uid = u.id
+           AND pt.company_id IS NULL
+           AND u.company_id IS NOT NULL
+        """
+    )
+    from_creator = cr.rowcount
+
+    cr.execute(
+        """
+        UPDATE project_task pt
+           SET company_id = u.company_id
+          FROM (
+              SELECT DISTINCT ON (rel.task_id)
+                     rel.task_id, rel.user_id
+                FROM project_task_user_rel rel
+            ORDER BY rel.task_id, rel.user_id
+          ) first_assignee
+          JOIN res_users u ON u.id = first_assignee.user_id
+         WHERE pt.id = first_assignee.task_id
+           AND pt.company_id IS NULL
+           AND u.company_id IS NOT NULL
+        """
+    )
+    from_assignee = cr.rowcount
+
+    if from_project + from_creator + from_assignee:
+        _logger.info(
+            "project 1.7: backfilled company_id on %d tasks "
+            "(project=%d, creator=%d, assignee=%d).",
+            from_project + from_creator + from_assignee,
+            from_project,
+            from_creator,
+            from_assignee,
+        )
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    Task = env["project.task"].with_context(
+        active_test=False,
+        tracking_disable=True,
+        mail_notrack=True,
+        mail_create_nosubscribe=True,
+    )
+    tasks = Task.search([])
+    if not tasks:
+        _logger.info("project 1.7: no tasks to recompute.")
+        return
+
+    _logger.info(
+        "project 1.7: recomputing PMI fields on %d tasks "
+        "(scheduled_hours -> planned_hours -> allocation_state).",
+        len(tasks),
+    )
+    tasks._compute_scheduled_hours()
+    tasks._compute_planned_hours()
+    tasks._compute_allocation_state()
+    tasks.flush_recordset(
+        ["scheduled_hours", "planned_hours", "allocation_state"]
+    )
+    _logger.info("project 1.7: PMI recompute complete.")

--- a/addons/project/migrations/1.7/pre-migrate.py
+++ b/addons/project/migrations/1.7/pre-migrate.py
@@ -1,0 +1,81 @@
+"""Pre-migration: PMI hours model on project.task (t20171).
+
+Introduces the three-tier hours model:
+
+- ``scheduled_hours``  — Duration in working time units (auto-computed
+  from ``planned_date_begin`` / ``date_end`` against the company
+  calendar).
+- ``planned_resources`` — Integer, planning intent: how many parallel
+  resources the PM expects to need.  Defaults to 1.
+- ``planned_hours`` — Effort: ``scheduled_hours × planned_resources``,
+  with manual override.  Pre-existing values are preserved (they
+  represent the legacy effort estimate).
+- ``allocated_hours`` — already present, computed by the scheduling
+  mixin as ``sum(reservation_ids.allocated_hours)``.
+- ``allocation_state`` — Selection signal of planning health (mirrors
+  invoice_state on sale.order).
+
+Migration steps:
+
+1. Add ``scheduled_hours`` (numeric, computed lazily on first read).
+2. Add ``planned_resources`` (integer, default 1 for all existing tasks).
+3. Add ``allocation_state`` (varchar, computed lazily).
+4. Backfill ``planned_hours`` from the legacy ``allocated_hours`` so
+   dashboards reading it as estimate keep their numbers — the value
+   represents PMI Effort intent and remains correct even after the
+   compute formula changes.
+5. (Optional) The old ``unallocated_hours`` column from an earlier
+   draft is dropped if present — superseded by ``allocation_state``.
+
+Idempotent: safe to re-run on partially migrated databases.
+
+See ``knowledge/agromarin-knowledge/reference/business/pmi-hours-model.md``.
+"""
+
+
+def _column_exists(cr, table, column):
+    cr.execute(
+        """
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = %s AND column_name = %s
+        """,
+        [table, column],
+    )
+    return bool(cr.fetchone())
+
+
+def migrate(cr, version):
+    if not _column_exists(cr, "project_task", "allocated_hours"):
+        # Fresh install or model not yet present; nothing to seed.
+        return
+
+    # planned_hours: backfill from legacy allocated_hours (effort intent).
+    if not _column_exists(cr, "project_task", "planned_hours"):
+        cr.execute("ALTER TABLE project_task ADD COLUMN planned_hours numeric")
+        cr.execute("UPDATE project_task SET planned_hours = allocated_hours")
+
+    # scheduled_hours: computed lazily on first read; column added empty.
+    if not _column_exists(cr, "project_task", "scheduled_hours"):
+        cr.execute("ALTER TABLE project_task ADD COLUMN scheduled_hours numeric")
+
+    # planned_resources: planning intent, default 1 for legacy tasks.
+    if not _column_exists(cr, "project_task", "planned_resources"):
+        cr.execute(
+            "ALTER TABLE project_task "
+            "ADD COLUMN planned_resources integer DEFAULT 1"
+        )
+        cr.execute(
+            "UPDATE project_task SET planned_resources = 1 "
+            "WHERE planned_resources IS NULL"
+        )
+
+    # allocation_state: computed lazily on first read.
+    if not _column_exists(cr, "project_task", "allocation_state"):
+        cr.execute(
+            "ALTER TABLE project_task ADD COLUMN allocation_state varchar"
+        )
+
+    # Drop the obsolete unallocated_hours column from an earlier draft of
+    # the PMI model (replaced by allocation_state).
+    if _column_exists(cr, "project_task", "unallocated_hours"):
+        cr.execute("ALTER TABLE project_task DROP COLUMN unallocated_hours")

--- a/addons/project/migrations/1.7/pre-migrate.py
+++ b/addons/project/migrations/1.7/pre-migrate.py
@@ -7,9 +7,8 @@ Introduces the three-tier hours model:
   calendar).
 - ``planned_resources`` — Integer, planning intent: how many parallel
   resources the PM expects to need.  Defaults to 1.
-- ``planned_hours`` — Effort: ``scheduled_hours × planned_resources``,
-  with manual override.  Pre-existing values are preserved (they
-  represent the legacy effort estimate).
+- ``planned_hours`` — Effort: ``scheduled_hours × planned_resources ×
+  (allocated_percentage / 100)``, with manual override.
 - ``allocated_hours`` — already present, computed by the scheduling
   mixin as ``sum(reservation_ids.allocated_hours)``.
 - ``allocation_state`` — Selection signal of planning health (mirrors
@@ -17,15 +16,17 @@ Introduces the three-tier hours model:
 
 Migration steps:
 
-1. Add ``scheduled_hours`` (numeric, computed lazily on first read).
+1. Add ``scheduled_hours`` (numeric, blank — recomputed in post-migrate).
 2. Add ``planned_resources`` (integer, default 1 for all existing tasks).
-3. Add ``allocation_state`` (varchar, computed lazily).
-4. Backfill ``planned_hours`` from the legacy ``allocated_hours`` so
-   dashboards reading it as estimate keep their numbers — the value
-   represents PMI Effort intent and remains correct even after the
-   compute formula changes.
-5. (Optional) The old ``unallocated_hours`` column from an earlier
-   draft is dropped if present — superseded by ``allocation_state``.
+3. Add ``planned_hours`` (numeric, blank — recomputed in post-migrate).
+4. Add ``allocation_state`` (varchar, blank — recomputed in post-migrate).
+5. Drop legacy ``unallocated_hours`` column if present.
+
+Legacy ``allocated_hours`` values are NOT copied into ``planned_hours``:
+the post-migrate forces a fresh recompute of all three PMI fields from
+the canonical inputs (dates, calendar, resources, allocated_percentage).
+Tasks without dates land at ``planned_hours = 0`` and ``allocation_state
+= unestimated``, which is the honest representation.
 
 Idempotent: safe to re-run on partially migrated databases.
 
@@ -49,25 +50,41 @@ def migrate(cr, version):
         # Fresh install or model not yet present; nothing to seed.
         return
 
-    # planned_hours: backfill from legacy allocated_hours (effort intent).
+    # planned_hours: column-only.  Value is recomputed in post-migrate
+    # from scheduled_hours x planned_resources x allocated_percentage.
     if not _column_exists(cr, "project_task", "planned_hours"):
         cr.execute("ALTER TABLE project_task ADD COLUMN planned_hours numeric")
-        cr.execute("UPDATE project_task SET planned_hours = allocated_hours")
 
-    # scheduled_hours: computed lazily on first read; column added empty.
+    # scheduled_hours: column-only.  Value is recomputed in post-migrate.
     if not _column_exists(cr, "project_task", "scheduled_hours"):
-        cr.execute("ALTER TABLE project_task ADD COLUMN scheduled_hours numeric")
+        cr.execute(
+            "ALTER TABLE project_task ADD COLUMN scheduled_hours numeric"
+        )
 
     # planned_resources: planning intent, default 1 for legacy tasks.
+    # Defensive cleanup against NULL / non-positive values before the
+    # CHECK (planned_resources > 0) constraint loads with the model.
     if not _column_exists(cr, "project_task", "planned_resources"):
         cr.execute(
             "ALTER TABLE project_task "
             "ADD COLUMN planned_resources integer DEFAULT 1"
         )
-        cr.execute(
-            "UPDATE project_task SET planned_resources = 1 "
-            "WHERE planned_resources IS NULL"
-        )
+    cr.execute(
+        "UPDATE project_task SET planned_resources = 1 "
+        "WHERE planned_resources IS NULL OR planned_resources <= 0"
+    )
+    # Ensure CHECK constraint is present even if _auto_init does not
+    # re-trigger on a same-version reinstall.  Idempotent.
+    cr.execute("""
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'project_task_planned_resources_positive'
+    """)
+    if not cr.fetchone():
+        cr.execute("""
+            ALTER TABLE project_task
+            ADD CONSTRAINT project_task_planned_resources_positive
+            CHECK (planned_resources > 0)
+        """)
 
     # allocation_state: computed lazily on first read.
     if not _column_exists(cr, "project_task", "allocation_state"):

--- a/addons/project/models/project_baseline.py
+++ b/addons/project/models/project_baseline.py
@@ -88,7 +88,7 @@ class ProjectBaseline(models.Model):
                 "task_name": task.name,
                 "planned_start": task.date_assign,
                 "planned_end": task.date_end,
-                "planned_hours": task.allocated_hours,
+                "planned_hours": task.planned_hours,
                 "milestone_id": task.milestone_id.id,
                 "step_id": task.step_id.id,
             }

--- a/addons/project/models/project_history.py
+++ b/addons/project/models/project_history.py
@@ -43,7 +43,7 @@ class ProjectHistory(models.Model):
         help="(actual - planned) / planned * 100. Positive = over-schedule.",
         export_string_translation=False,
     )
-    planned_hours = fields.Float("Planned Hours (sum of allocated_hours)")
+    planned_hours = fields.Float("Planned Hours (sum of task.planned_hours)")
     actual_hours = fields.Float(
         "Actual Hours",
         help="Sum of effective_hours (requires timesheet module).",
@@ -124,8 +124,8 @@ class ProjectHistory(models.Model):
         if project.date_start:
             actual_days = (fields.Date.today() - project.date_start).days
 
-        # Aggregate hours
-        planned_hours = sum(tasks.mapped("allocated_hours"))
+        # Aggregate hours (PMI: scope baseline = sum of estimates).
+        planned_hours = sum(tasks.mapped("planned_hours"))
 
         # Actual hours — only available if timesheet module installed
         actual_hours = 0.0

--- a/addons/project/models/project_sprint.py
+++ b/addons/project/models/project_sprint.py
@@ -75,13 +75,13 @@ class ProjectSprint(models.Model):
     committed_hours = fields.Float(
         "Committed Hours",
         compute="_compute_task_metrics",
-        help="Sum of allocated_hours for all sprint tasks.",
+        help="Sum of planned_hours for all sprint tasks (PMI scope baseline).",
         export_string_translation=False,
     )
     velocity = fields.Float(
         "Velocity (hours)",
         compute="_compute_task_metrics",
-        help="Sum of allocated_hours for completed sprint tasks.",
+        help="Sum of planned_hours for completed sprint tasks.",
         export_string_translation=False,
     )
     story_points_committed = fields.Float(
@@ -102,7 +102,7 @@ class ProjectSprint(models.Model):
 
     @api.depends(
         "task_ids", "task_ids.state",
-        "task_ids.allocated_hours", "task_ids.story_points",
+        "task_ids.planned_hours", "task_ids.story_points",
     )
     def _compute_task_metrics(self) -> None:
         """Compute sprint metrics from task data."""
@@ -114,8 +114,8 @@ class ProjectSprint(models.Model):
             sprint.completion_pct = (
                 len(closed) / len(tasks) * 100 if tasks else 0.0
             )
-            sprint.committed_hours = sum(tasks.mapped("allocated_hours"))
-            sprint.velocity = sum(closed.mapped("allocated_hours"))
+            sprint.committed_hours = sum(tasks.mapped("planned_hours"))
+            sprint.velocity = sum(closed.mapped("planned_hours"))
             # Story points — only if tasks have the field populated
             sprint.story_points_committed = sum(tasks.mapped("story_points"))
             sprint.story_points_completed = sum(closed.mapped("story_points"))

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -10,8 +10,14 @@ from pytz import UTC
 from odoo import SUPERUSER_ID, _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command, Date, Domain
-from odoo.tools import SQL, LazyTranslate, format_list, html_sanitize
-from odoo.tools.date_utils import localized
+from odoo.tools import (
+    SQL,
+    LazyTranslate,
+    float_compare,
+    float_is_zero,
+    format_list,
+    html_sanitize,
+)
 
 from odoo.addons.html_editor.tools import handle_history_divergence
 from odoo.addons.mail.tools.discuss import Store
@@ -372,15 +378,8 @@ class ProjectTask(models.Model):
     )
     tag_ids = fields.Many2many("project.tags", string="Tags")
 
-    # PMI hours model (see reference/business/pmi-hours-model.md):
-    # Three-tier intent → effort → commitment:
-    # - scheduled_hours:   working hours within the date range (Duration in
-    #                      working time units).
-    # - planned_resources: intent, how many resources the PM expects to need.
-    # - planned_hours:     scheduled x planned_resources (PMBOK Effort / Work).
-    # - allocated_hours:   sum(reservation_ids.allocated_hours) via mixin.
-    # - allocation_state:  health signal (unestimated / unallocated /
-    #                      under_allocated / allocated / over_allocated).
+    # PMI hours model: scheduled (duration) -> planned (effort) ->
+    # allocated (commitment). See reference/business/pmi-hours-model.md.
     scheduled_hours = fields.Float(
         "Working Duration",
         compute="_compute_scheduled_hours",
@@ -399,15 +398,19 @@ class ProjectTask(models.Model):
         "with planned_resources=2 -> 32h effort = work for two people in "
         "parallel.  PMBOK: planned resource units.",
     )
+    _planned_resources_positive = models.Constraint(
+        "CHECK (planned_resources > 0)",
+        "Planned Resources must be greater than zero.",
+    )
     planned_hours = fields.Float(
         "Planned Hours",
         compute="_compute_planned_hours",
+        inverse="_inverse_planned_hours",
         store=True,
         readonly=False,
-        tracking=True,
         help="Estimated person-hours to complete the task.  Auto-derived as "
-        "scheduled_hours x planned_resources; user can override.  "
-        "PMBOK: Activity Effort / Work (scope baseline).",
+        "scheduled_hours x planned_resources x (allocated_percentage / 100); "
+        "user can override.  PMBOK: Activity Effort / Work (scope baseline).",
     )
     allocated_hours = fields.Float(
         "Allocated Hours",
@@ -629,7 +632,11 @@ class ProjectTask(models.Model):
     is_overallocated = fields.Boolean(
         "Overallocated Assignee",
         compute="_compute_is_overallocated",
-        help="True when any assignee has > 40h allocated across all open tasks.",
+        help=(
+            "True when any of this task's reservations conflicts in time "
+            "with another reservation of the same resource summing more "
+            "than 100% allocation (PMBOK concurrent overcommit)."
+        ),
         export_string_translation=False,
     )
 
@@ -1503,40 +1510,19 @@ class ProjectTask(models.Model):
             else:
                 task.cd3_score = 0.0
 
-    @api.depends("user_ids")
+    @api.depends("reservation_ids.schedule_overlap_count")
     def _compute_is_overallocated(self) -> None:
-        """Check if any assignee has > 40h allocated across all open tasks."""
-        all_user_ids = set()
-        for task in self:
-            all_user_ids.update(task.user_ids.ids)
-        if not all_user_ids:
-            self.is_overallocated = False
-            return
+        """Concurrent overcommit on any of this task's reservations.
 
-        # Per-user commitment hours come from the per-resource reservation
-        # ledger (NOT task.allocated_hours, which now sums across all
-        # assignees and would double-count under task_user_rel join).
-        self.env.cr.execute(
-            SQL(
-                """
-            SELECT res.user_id, SUM(rr.allocated_hours)
-            FROM resource_reservation rr
-            JOIN resource_resource res ON res.id = rr.resource_id
-            JOIN project_task t
-                 ON t.id = rr.res_id
-                AND rr.res_model = 'project.task'
-            WHERE res.user_id IN %(user_ids)s
-              AND t.state NOT IN ('done', 'canceled')
-              AND t.is_template = FALSE
-            GROUP BY res.user_id
-            HAVING SUM(rr.allocated_hours) > 40
-            """,
-                user_ids=tuple(all_user_ids),
-            )
-        )
-        overallocated_users = {row[0] for row in self.env.cr.fetchall()}
+        Delegates to ``resource.reservation.schedule_overlap_count``,
+        which counts other reservations of the same resource overlapping
+        in time AND summing > 100% allocation.  Captures real PMBOK
+        overallocation (concurrency, not lifetime backlog volume).
+        """
         for task in self:
-            task.is_overallocated = bool(overallocated_users & set(task.user_ids.ids))
+            task.is_overallocated = any(
+                r.schedule_overlap_count for r in task.reservation_ids
+            )
 
     def _compute_access_url(self) -> None:
         super()._compute_access_url()
@@ -1554,72 +1540,64 @@ class ProjectTask(models.Model):
         "company_id",
     )
     def _compute_scheduled_hours(self) -> None:
-        """Working hours within the task's scheduled range.
-
-        Computed against the company calendar (respects working days,
-        compute_leaves=True so lunch and holidays don't count).  This is
-        the *Duration* leg of the PMI triangle (Effort = Duration x Units);
-        ``planned_hours`` multiplies it by ``planned_resources`` to get
-        total effort.
-        """
+        """Working hours within the task's scheduled range."""
         for task in self:
-            if not task.planned_date_begin or not task.date_end:
-                task.scheduled_hours = 0.0
-                continue
-            calendar = (
-                task.company_id.resource_calendar_id
-                or task.env.company.resource_calendar_id
-            )
-            if not calendar:
-                task.scheduled_hours = 0.0
-                continue
             task.scheduled_hours = round(
-                calendar.get_work_hours_count(
-                    localized(task.planned_date_begin),
-                    localized(task.date_end),
+                task._scheduling_get_work_hours(
+                    task.planned_date_begin,
+                    task.date_end,
                     compute_leaves=True,
                 ),
                 2,
             )
 
-    @api.depends("scheduled_hours", "planned_resources")
+    @api.depends(
+        "scheduled_hours", "planned_resources", "allocated_percentage"
+    )
     def _compute_planned_hours(self) -> None:
-        """Total effort = scheduled hours x planned resource units.
-
-        Auto-derived following PMI's Effort = Duration x Resources formula.
-        ``readonly=False`` lets users override when the math doesn't fit
-        (e.g., a single resource at fractional allocation); the override
-        sticks until ``scheduled_hours`` or ``planned_resources`` changes.
-        """
+        """PMBOK Effort = Duration x Resources x Units (uniform rate)."""
         for task in self:
             task.planned_hours = round(
-                task.scheduled_hours * (task.planned_resources or 1),
+                task.scheduled_hours
+                * task.planned_resources
+                * (task.allocated_percentage / 100.0),
                 2,
+            )
+
+    def _inverse_planned_hours(self) -> None:
+        """Track manual overrides of the PMBOK-derived planned_hours.
+
+        ``planned_hours`` is a stored compute with ``readonly=False``: Odoo
+        calls this inverse only on direct user writes, not on
+        dependency-driven recomputes.  Posting from here keeps the chatter
+        signal precise (override events) without the noise that
+        ``tracking=True`` would generate on every formula recompute.
+        """
+        for task in self:
+            task.message_post(
+                body=_(
+                    "Planned Hours manually overridden to %(value).2f h "
+                    "(formula override).",
+                    value=task.planned_hours,
+                ),
             )
 
     @api.depends("planned_hours", "allocated_hours")
     def _compute_allocation_state(self) -> None:
-        """Resource allocation health relative to plan.
-
-        Mirrors the ``invoice_state`` pattern on ``sale.order``.  States:
-
-        - ``unestimated``: no planned_hours yet (no dates / no resources).
-        - ``unallocated``: estimate exists but no resources committed.
-        - ``under_allocated``: some commitment but less than estimate.
-        - ``allocated``: commitment matches estimate (within tolerance).
-        - ``over_allocated``: commitment exceeds estimate (PM over-asignó).
-        """
-        TOLERANCE = 0.01
+        """Resource allocation health relative to plan."""
         for task in self:
-            if task.planned_hours <= 0:
+            if float_is_zero(task.planned_hours, precision_digits=2):
                 task.allocation_state = "unestimated"
                 continue
-            diff = task.allocated_hours - task.planned_hours
-            if task.allocated_hours <= 0:
+            if float_is_zero(task.allocated_hours, precision_digits=2):
                 task.allocation_state = "unallocated"
-            elif abs(diff) < TOLERANCE:
+                continue
+            delta = float_compare(
+                task.allocated_hours, task.planned_hours, precision_digits=2
+            )
+            if delta == 0:
                 task.allocation_state = "allocated"
-            elif diff > 0:
+            elif delta > 0:
                 task.allocation_state = "over_allocated"
             else:
                 task.allocation_state = "under_allocated"

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -11,6 +11,7 @@ from odoo import SUPERUSER_ID, _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Command, Date, Domain
 from odoo.tools import SQL, LazyTranslate, format_list, html_sanitize
+from odoo.tools.date_utils import localized
 
 from odoo.addons.html_editor.tools import handle_history_divergence
 from odoo.addons.mail.tools.discuss import Store
@@ -75,6 +76,7 @@ PROJECT_TASK_WRITABLE_FIELDS = {
     "name",
     "description",
     "partner_id",
+    "planned_date_begin",
     "date_end",
     "date_last_status_change",
     "tag_ids",
@@ -260,11 +262,24 @@ class ProjectTask(models.Model):
         readonly=True,
         help="Date on which this task was last assigned (or unassigned). Based on this, you can get statistics on the time it usually takes to assign tasks.",
     )
+    # Scheduled time range — PMI Constraint Start Date / Constraint End Date.
+    # User-entered values (independent of CPM-calculated planned_date_start /
+    # planned_date_end above).  ``date_end`` doubles as the deadline label
+    # for backward compatibility with vanilla Odoo's project module.
+    planned_date_begin = fields.Datetime(
+        "Start date",
+        tracking=True,
+        copy=False,
+    )
     date_end = fields.Datetime(
         string="Deadline",
         index=True,
         tracking=True,
         copy=False,
+    )
+    _planned_dates_check = models.Constraint(
+        "CHECK ((planned_date_begin <= date_end))",
+        "The planned start date must be before the planned end date.",
     )
 
     priority = fields.Selection(
@@ -357,17 +372,75 @@ class ProjectTask(models.Model):
     )
     tag_ids = fields.Many2many("project.tags", string="Tags")
 
-    allocated_hours = fields.Float("Allocated Time", tracking=True)
-    allocated_percentage = fields.Float(
-        "Allocation %",
-        default=100.0,
-        help="Percentage of each assignee's work capacity allocated to this task.",
+    # PMI hours model (see reference/business/pmi-hours-model.md):
+    # Three-tier intent → effort → commitment:
+    # - scheduled_hours:   working hours within the date range (Duration in
+    #                      working time units).
+    # - planned_resources: intent, how many resources the PM expects to need.
+    # - planned_hours:     scheduled x planned_resources (PMBOK Effort / Work).
+    # - allocated_hours:   sum(reservation_ids.allocated_hours) via mixin.
+    # - allocation_state:  health signal (unestimated / unallocated /
+    #                      under_allocated / allocated / over_allocated).
+    scheduled_hours = fields.Float(
+        "Working Duration",
+        compute="_compute_scheduled_hours",
+        store=True,
+        help="Working hours within the task's date range, computed against "
+        "the company calendar.  PMBOK: Activity Duration in working time "
+        "units.  One person at 100%% allocation could cover this many hours.",
     )
-    subtask_allocated_hours = fields.Float(
-        "Sub-tasks Allocated Time",
-        compute="_compute_subtask_allocated_hours",
+    planned_resources = fields.Integer(
+        "Planned Resources",
+        default=1,
+        tracking=True,
+        help="Number of parallel resources the PM expects to need to deliver "
+        "this task in its scheduled window.  Multiplies scheduled_hours to "
+        "derive total effort (planned_hours).  Example: 2-day window (16h) "
+        "with planned_resources=2 -> 32h effort = work for two people in "
+        "parallel.  PMBOK: planned resource units.",
+    )
+    planned_hours = fields.Float(
+        "Planned Hours",
+        compute="_compute_planned_hours",
+        store=True,
+        readonly=False,
+        tracking=True,
+        help="Estimated person-hours to complete the task.  Auto-derived as "
+        "scheduled_hours x planned_resources; user can override.  "
+        "PMBOK: Activity Effort / Work (scope baseline).",
+    )
+    allocated_hours = fields.Float(
+        "Allocated Hours",
+        tracking=True,
+        help="Working hours committed across all assigned employees "
+        "(sum of reservation_ids.allocated_hours).  PMBOK: Resource "
+        "Assignment Work / total person-hours.",
+    )
+    allocation_state = fields.Selection(
+        [
+            ("unestimated", "Unestimated"),
+            ("unallocated", "Unallocated"),
+            ("under_allocated", "Under-Allocated"),
+            ("allocated", "Allocated"),
+            ("over_allocated", "Over-Allocated"),
+        ],
+        string="Allocation Status",
+        compute="_compute_allocation_state",
+        store=True,
+        help="Resource allocation health relative to plan.  Tracks whether "
+        "the task has enough employees committed to cover its planned "
+        "effort.  Operational signal for PMs.  Pattern analog to "
+        "invoice_state on sale.order.",
+    )
+    # allocated_percentage inherited from resource.scheduling.mixin —
+    # uniform fractional allocation passed through to every reservation
+    # via _get_reservation_vals_list.  Per-resource fractional units (PMI
+    # strict per-assignment Units) lives on resource.reservation.
+    subtask_planned_hours = fields.Float(
+        "Sub-tasks Planned Hours",
+        compute="_compute_subtask_planned_hours",
         export_string_translation=False,
-        help="Sum of the hours allocated for all the sub-tasks (and their own sub-tasks) linked to this task. Usually less than or equal to the allocated hours of this task.",
+        help="Sum of the planned hours for all the sub-tasks (and their own sub-tasks) linked to this task. Usually less than or equal to the planned hours of this task.",
     )
     # User names displayed in project sharing views
     portal_user_names = fields.Char(
@@ -637,7 +710,7 @@ class ProjectTask(models.Model):
         store=True,
         help=(
             "Cost of Delay Divided by Duration (CD3). Higher = do first. "
-            "Computed as cost_of_delay / allocated_hours when both are set."
+            "Computed as cost_of_delay / planned_hours when both are set."
         ),
         export_string_translation=False,
     )
@@ -1417,12 +1490,16 @@ class ProjectTask(models.Model):
                     task.date_closed and task.date_closed <= task.date_end
                 )
 
-    @api.depends("cost_of_delay", "allocated_hours")
+    @api.depends("cost_of_delay", "planned_hours")
     def _compute_cd3_score(self) -> None:
-        """Compute Cost of Delay Divided by Duration for value-based prioritization."""
+        """Compute Cost of Delay Divided by Duration for value-based prioritization.
+
+        Uses ``planned_hours`` (estimate-based) so prioritization works
+        even before resources are assigned.  See PMI hours model.
+        """
         for task in self:
-            if task.cost_of_delay and task.allocated_hours:
-                task.cd3_score = task.cost_of_delay / task.allocated_hours
+            if task.cost_of_delay and task.planned_hours:
+                task.cd3_score = task.cost_of_delay / task.planned_hours
             else:
                 task.cd3_score = 0.0
 
@@ -1436,18 +1513,23 @@ class ProjectTask(models.Model):
             self.is_overallocated = False
             return
 
-        # Single query: total allocated hours per user across open tasks
+        # Per-user commitment hours come from the per-resource reservation
+        # ledger (NOT task.allocated_hours, which now sums across all
+        # assignees and would double-count under task_user_rel join).
         self.env.cr.execute(
             SQL(
                 """
-            SELECT rel.user_id, SUM(t.allocated_hours)
-            FROM project_task t
-            JOIN project_task_user_rel rel ON rel.task_id = t.id
-            WHERE rel.user_id IN %(user_ids)s
+            SELECT res.user_id, SUM(rr.allocated_hours)
+            FROM resource_reservation rr
+            JOIN resource_resource res ON res.id = rr.resource_id
+            JOIN project_task t
+                 ON t.id = rr.res_id
+                AND rr.res_model = 'project.task'
+            WHERE res.user_id IN %(user_ids)s
               AND t.state NOT IN ('done', 'canceled')
               AND t.is_template = FALSE
-            GROUP BY rel.user_id
-            HAVING SUM(t.allocated_hours) > 40
+            GROUP BY res.user_id
+            HAVING SUM(rr.allocated_hours) > 40
             """,
                 user_ids=tuple(all_user_ids),
             )
@@ -1461,10 +1543,86 @@ class ProjectTask(models.Model):
         for task in self:
             task.access_url = f"/my/tasks/{task.id}"
 
-    @api.depends("child_ids.allocated_hours")
-    def _compute_subtask_allocated_hours(self) -> None:
+    @api.depends("child_ids.planned_hours")
+    def _compute_subtask_planned_hours(self) -> None:
         for task in self:
-            task.subtask_allocated_hours = sum(task.child_ids.mapped("allocated_hours"))
+            task.subtask_planned_hours = sum(task.child_ids.mapped("planned_hours"))
+
+    @api.depends(
+        "planned_date_begin",
+        "date_end",
+        "company_id",
+    )
+    def _compute_scheduled_hours(self) -> None:
+        """Working hours within the task's scheduled range.
+
+        Computed against the company calendar (respects working days,
+        compute_leaves=True so lunch and holidays don't count).  This is
+        the *Duration* leg of the PMI triangle (Effort = Duration x Units);
+        ``planned_hours`` multiplies it by ``planned_resources`` to get
+        total effort.
+        """
+        for task in self:
+            if not task.planned_date_begin or not task.date_end:
+                task.scheduled_hours = 0.0
+                continue
+            calendar = (
+                task.company_id.resource_calendar_id
+                or task.env.company.resource_calendar_id
+            )
+            if not calendar:
+                task.scheduled_hours = 0.0
+                continue
+            task.scheduled_hours = round(
+                calendar.get_work_hours_count(
+                    localized(task.planned_date_begin),
+                    localized(task.date_end),
+                    compute_leaves=True,
+                ),
+                2,
+            )
+
+    @api.depends("scheduled_hours", "planned_resources")
+    def _compute_planned_hours(self) -> None:
+        """Total effort = scheduled hours x planned resource units.
+
+        Auto-derived following PMI's Effort = Duration x Resources formula.
+        ``readonly=False`` lets users override when the math doesn't fit
+        (e.g., a single resource at fractional allocation); the override
+        sticks until ``scheduled_hours`` or ``planned_resources`` changes.
+        """
+        for task in self:
+            task.planned_hours = round(
+                task.scheduled_hours * (task.planned_resources or 1),
+                2,
+            )
+
+    @api.depends("planned_hours", "allocated_hours")
+    def _compute_allocation_state(self) -> None:
+        """Resource allocation health relative to plan.
+
+        Mirrors the ``invoice_state`` pattern on ``sale.order``.  States:
+
+        - ``unestimated``: no planned_hours yet (no dates / no resources).
+        - ``unallocated``: estimate exists but no resources committed.
+        - ``under_allocated``: some commitment but less than estimate.
+        - ``allocated``: commitment matches estimate (within tolerance).
+        - ``over_allocated``: commitment exceeds estimate (PM over-asignó).
+        """
+        TOLERANCE = 0.01
+        for task in self:
+            if task.planned_hours <= 0:
+                task.allocation_state = "unestimated"
+                continue
+            diff = task.allocated_hours - task.planned_hours
+            if task.allocated_hours <= 0:
+                task.allocation_state = "unallocated"
+            elif abs(diff) < TOLERANCE:
+                task.allocation_state = "allocated"
+            elif diff > 0:
+                task.allocation_state = "over_allocated"
+            else:
+                task.allocation_state = "under_allocated"
 
     @api.depends("child_ids")
     def _compute_subtask_count(self) -> None:
@@ -2392,12 +2550,8 @@ class ProjectTask(models.Model):
     # ------------------------------------------------------------------
 
     def _get_reservation_date_fields(self):
-        """Return (start_field, end_field) names for reservation sync.
-
-        Core returns (None, None) because ``planned_date_begin`` only exists
-        in the enterprise layer (``project_enterprise`` overrides this).
-        """
-        return (None, None)
+        """Return (start_field, end_field) names for reservation sync."""
+        return ("planned_date_begin", "date_end")
 
     def _get_reservation_vals_list(self):
         """Build one reservation dict per assignee with a resolvable resource.
@@ -2449,6 +2603,74 @@ class ProjectTask(models.Model):
         triggers = super()._get_sync_trigger_fields()
         triggers |= {"user_ids", "allocated_percentage"}
         return triggers
+
+    @api.onchange("date_end", "planned_date_begin")
+    def _onchange_planned_dates(self):
+        """Clear ``planned_date_begin`` when ``date_end`` is removed.
+
+        Data invariant: a scheduled-start without a scheduled-end is a
+        meaningless schedule.  Mirrors what users expect when they
+        unschedule a task by clearing the deadline.
+        """
+        if not self.date_end:
+            self.planned_date_begin = False
+
+    def action_unschedule_task(self):
+        """Clear scheduling dates (used by gantt 'unschedule' action)."""
+        self.write({
+            "planned_date_begin": False,
+            "date_end": False,
+        })
+
+    @api.model
+    def _calculate_planned_dates(
+        self, date_start, date_stop, user_id=None, calendar=None
+    ):
+        """Snap a (start, stop) range to the first/last working intervals.
+
+        Returns the input range unchanged when no calendar is resolvable
+        or when the range falls entirely outside working time.  Used by
+        ``project_enterprise`` for gantt drag-on-calendar UX, and
+        available to any consumer that needs calendar-aware date alignment.
+        """
+        if not (date_start and date_stop):
+            raise UserError(
+                _(
+                    "One parameter is missing to use this method. "
+                    "You should give a start and end dates."
+                )
+            )
+        start, stop = date_start, date_stop
+        if isinstance(start, str):
+            start = fields.Datetime.from_string(start)
+        if isinstance(stop, str):
+            stop = fields.Datetime.from_string(stop)
+
+        if not calendar:
+            user = (
+                self.env["res.users"].sudo().browse(user_id)
+                if user_id and user_id != self.env.user.id
+                else self.env.user
+            )
+            calendar = (
+                user.resource_calendar_id
+                or self.env.company.resource_calendar_id
+            )
+            if not calendar:
+                return date_start, date_stop
+
+        if not start.tzinfo:
+            start = start.replace(tzinfo=UTC)
+        if not stop.tzinfo:
+            stop = stop.replace(tzinfo=UTC)
+
+        intervals = calendar._work_intervals_batch(start, stop)[False]
+        if not intervals:
+            return date_start, date_stop
+        list_intervals = [(s, e) for s, e, _records in intervals]
+        start = list_intervals[0][0].astimezone(UTC).replace(tzinfo=None)
+        stop = list_intervals[-1][1].astimezone(UTC).replace(tzinfo=None)
+        return start, stop
 
     def action_view_schedule(self):
         """Open the reservation view filtered to the assignees' resources.

--- a/addons/project/report/project_resource_report.py
+++ b/addons/project/report/project_resource_report.py
@@ -42,22 +42,34 @@ class ProjectResourceReport(models.Model):
     )
 
     def init(self) -> None:
-        """Create the SQL view for resource utilization."""
+        """Create the SQL view for resource utilization.
+
+        Sources ``allocated_hours`` from ``resource_reservation`` (per-resource
+        ledger) — NOT from ``project_task.allocated_hours``, which sums
+        across all assignees and would double-count multi-user tasks
+        when joined through ``project_task_user_rel``.  See PMI hours
+        model: this report measures actual resource commitment, so the
+        per-resource reservation row is canonical.
+        """
         tools.drop_view_if_exists(self.env.cr, self._table)
         self.env.cr.execute(f"""
             CREATE OR REPLACE VIEW {self._table} AS (
                 WITH user_project AS (
                     SELECT
-                        rel.user_id,
+                        res.user_id,
                         t.project_id,
-                        SUM(t.allocated_hours) AS allocated_hours,
-                        COUNT(*) AS task_count
-                    FROM project_task t
-                    JOIN project_task_user_rel rel ON rel.task_id = t.id
+                        SUM(rr.allocated_hours) AS allocated_hours,
+                        COUNT(DISTINCT t.id) AS task_count
+                    FROM resource_reservation rr
+                    JOIN resource_resource res ON res.id = rr.resource_id
+                    JOIN project_task t
+                         ON t.id = rr.res_id
+                        AND rr.res_model = 'project.task'
                     WHERE t.state NOT IN ('done', 'canceled')
                       AND t.project_id IS NOT NULL
                       AND t.is_template = FALSE
-                    GROUP BY rel.user_id, t.project_id
+                      AND res.user_id IS NOT NULL
+                    GROUP BY res.user_id, t.project_id
                 ),
                 user_totals AS (
                     SELECT

--- a/addons/project/report/project_task_burndown_chart_report.py
+++ b/addons/project/report/project_task_burndown_chart_report.py
@@ -17,7 +17,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
     _auto = False
     _order = "date"
 
-    allocated_hours = fields.Float(string="Allocated Time", readonly=True)
+    planned_hours = fields.Float(string="Planned Hours", readonly=True)
     date = fields.Datetime("Date", readonly=True)
     date_assign = fields.Datetime(string="Assignment Date", readonly=True)
     date_end = fields.Date(string="Deadline", readonly=True)
@@ -145,7 +145,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
               WITH task_ids AS %(task_query_subselect)s,
               all_step_task_moves AS (
                  SELECT count(*) as __count,
-                        sum(allocated_hours) as allocated_hours,
+                        sum(planned_hours) as planned_hours,
                         project_id,
                         %(date_begin)s as date_begin,
                         %(date_end)s as date_end,
@@ -153,7 +153,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
                         is_closed
                    FROM (
                             SELECT DISTINCT task_id,
-                                   allocated_hours,
+                                   planned_hours,
                                    project_id,
                                    %(date_begin)s as date_begin,
                                    %(date_end)s as date_end,
@@ -161,7 +161,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
                                    is_closed
                               FROM (
                                      SELECT pt.id as task_id,
-                                            pt.allocated_hours,
+                                            pt.planned_hours,
                                             pt.project_id,
                                             COALESCE(LAG(mm.date) OVER (PARTITION BY mm.res_id ORDER BY mm.id), pt.create_date) as date_begin,
                                             CASE WHEN mtv.id IS NOT NULL THEN mm.date
@@ -188,7 +188,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
                                       WHERE pt.active=true AND pt.id IN (SELECT id from task_ids)
                                    ) task_step_id_history
                           GROUP BY task_id,
-                                   allocated_hours,
+                                   planned_hours,
                                    project_id,
                                    %(date_begin)s,
                                    %(date_end)s,
@@ -197,7 +197,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
                             WINDOW task_date_begin_window AS (PARTITION BY task_id, %(date_begin)s)
                           UNION ALL
                             SELECT pt.id as task_id,
-                                   pt.allocated_hours,
+                                   pt.planned_hours,
                                    pt.project_id,
                                    last_step_id_change_mail_message.date as date_begin,
                                    (now() at time zone 'utc')::date + INTERVAL '%(interval)s' as date_end,
@@ -219,7 +219,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
                                    ) AS last_step_id_change_mail_message ON TRUE
                              WHERE pt.active=true AND pt.id IN (SELECT id from task_ids)
                         ) AS project_task_burndown_chart
-               GROUP BY allocated_hours,
+               GROUP BY planned_hours,
                         project_id,
                         %(date_begin)s,
                         %(date_end)s,
@@ -227,7 +227,7 @@ class ProjectTaskBurndownChartReport(models.AbstractModel):
                         is_closed
               )
               SELECT (project_id*10^13 + step_id*10^7 + to_char(date, 'YYMMDD')::integer)::bigint as id,
-                     allocated_hours,
+                     planned_hours,
                      project_id,
                      step_id,
                      is_closed,

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -266,9 +266,9 @@
                                         <t t-call="project.portal_my_tasks_priority_widget_template"/>
                                     </div>
                                     <div t-if="task.date_end"><strong>Deadline:</strong> <span t-field="task.date_end" t-options='{"widget": "datetime"}'/></div>
-                                    <div name="portal_my_task_allocated_hours">
-                                        <strong t-if="task.allocated_hours > 0">Allocated Time:</strong>
-                                        <t t-call="project.portal_my_task_allocated_hours_template"/>
+                                    <div name="portal_my_task_planned_hours">
+                                        <strong t-if="task.planned_hours > 0">Planned Time:</strong>
+                                        <t t-call="project.portal_my_task_planned_hours_template"/>
                                     </div>
                                 </div>
                                 <div class="col-12 col-md-6 d-empty-none" name="portal_my_task_second_column"></div>
@@ -318,8 +318,8 @@
         </xpath>
     </template>
 
-    <template id="portal_my_task_allocated_hours_template">
-        <strong t-if="task.allocated_hours > 0" class="d-none">Allocated Time:</strong>
-        <span t-out="task.allocated_hours" t-options='{"widget": "float_time"}'/>
+    <template id="portal_my_task_planned_hours_template">
+        <strong t-if="task.planned_hours > 0" class="d-none">Planned Time:</strong>
+        <span t-out="task.planned_hours" t-options='{"widget": "float_time"}'/>
     </template>
 </odoo>

--- a/addons/project/views/project_sprint_views.xml
+++ b/addons/project/views/project_sprint_views.xml
@@ -75,7 +75,7 @@
                         <list>
                             <field name="name"/>
                             <field name="user_ids" widget="many2many_avatar_user"/>
-                            <field name="allocated_hours" widget="float_time"/>
+                            <field name="planned_hours" widget="float_time"/>
                             <field name="story_points" optional="show"/>
                             <field name="state"/>
                             <field name="step_id" optional="hide"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -231,6 +231,8 @@
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
                     <field name="step_color" invisible="1"/>
+                    <field name="scheduled_hours" widget="float_time"/>
+                    <field name="planned_hours" widget="float_time"/>
                     <field name="allocated_hours" widget="float_time"/>
                     <field name="lead_time_hours" widget="float_time"/>
                     <field name="queue_time_hours" widget="float_time"/>
@@ -510,8 +512,17 @@
                                 <field name="repeat_until" invisible="repeat_type != 'until'" required="repeat_type == 'until'"
                                        class="me-2" />
                             </div>
-                            <!-- Field needed to trigger its compute in project_enterprise, but will be replaced in an override defined in hr_timesheet module -->
-                            <field name="allocated_hours" invisible="1"/>
+                            <!-- PMI hours model: scheduled (Duration), planned_resources (Units), planned (Effort), allocated (commitment) -->
+                            <field name="scheduled_hours" widget="float_time" readonly="1"/>
+                            <field name="planned_resources"/>
+                            <field name="planned_hours" widget="float_time"/>
+                            <field name="allocated_hours" widget="float_time" readonly="1"/>
+                            <field name="allocation_state" widget="badge"
+                                   decoration-muted="allocation_state == 'unestimated'"
+                                   decoration-info="allocation_state == 'unallocated'"
+                                   decoration-warning="allocation_state == 'under_allocated'"
+                                   decoration-success="allocation_state == 'allocated'"
+                                   decoration-danger="allocation_state == 'over_allocated'"/>
                             <field name="allocated_percentage" invisible="1"/>
                             <field name="schedule_overlap_count" invisible="1"/>
                         </group>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -400,6 +400,12 @@
                     </header>
                     <!-- Used in inherited views to display the eventual warnings -->
                     <t name="warning_section"/>
+                    <field name="is_overallocated" invisible="1"/>
+                    <div class="alert alert-warning d-flex align-items-center" role="alert"
+                         invisible="not is_overallocated">
+                        <i class="fa fa-exclamation-triangle me-2" aria-hidden="true"/>
+                        <span>An assignee on this task is over-allocated: a reservation conflicts in time with another assignment summing more than 100% allocation.</span>
+                    </div>
                     <sheet string="Task">
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
                         <!-- Dummy tag for organizing buttons, using position='replace' when inheriting -->
@@ -512,17 +518,6 @@
                                 <field name="repeat_until" invisible="repeat_type != 'until'" required="repeat_type == 'until'"
                                        class="me-2" />
                             </div>
-                            <!-- PMI hours model: scheduled (Duration), planned_resources (Units), planned (Effort), allocated (commitment) -->
-                            <field name="scheduled_hours" widget="float_time" readonly="1"/>
-                            <field name="planned_resources"/>
-                            <field name="planned_hours" widget="float_time"/>
-                            <field name="allocated_hours" widget="float_time" readonly="1"/>
-                            <field name="allocation_state" widget="badge"
-                                   decoration-muted="allocation_state == 'unestimated'"
-                                   decoration-info="allocation_state == 'unallocated'"
-                                   decoration-warning="allocation_state == 'under_allocated'"
-                                   decoration-success="allocation_state == 'allocated'"
-                                   decoration-danger="allocation_state == 'over_allocated'"/>
                             <field name="allocated_percentage" invisible="1"/>
                             <field name="schedule_overlap_count" invisible="1"/>
                         </group>
@@ -672,12 +667,18 @@
                                     <field name="cost_of_delay"/>
                                     <field name="cd3_score" invisible="not cd3_score"/>
                                 </group>
-                                <group string="Scheduling" invisible="not allow_dependencies">
-                                    <field name="is_critical_path"/>
-                                    <field name="total_float" widget="float_time" invisible="not is_critical_path and total_float == 0"/>
-                                    <field name="planned_date_start" readonly="True"/>
-                                    <field name="planned_date_end" readonly="True"/>
-                                    <field name="is_overallocated"/>
+                                <group string="Scheduling">
+                                    <!-- PMI hours: scheduled (Duration), planned_resources (Units), planned (Effort), allocated (commitment) -->
+                                    <field name="scheduled_hours" widget="float_time" readonly="1"/>
+                                    <field name="planned_resources"/>
+                                    <field name="planned_hours" widget="float_time"/>
+                                    <field name="allocated_hours" widget="float_time" readonly="1"/>
+                                    <field name="allocation_state" widget="badge"
+                                           decoration-muted="allocation_state == 'unestimated'"
+                                           decoration-info="allocation_state == 'unallocated'"
+                                           decoration-warning="allocation_state == 'under_allocated'"
+                                           decoration-success="allocation_state == 'allocated'"
+                                           decoration-danger="allocation_state == 'over_allocated'"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/project_hr/__manifest__.py
+++ b/addons/project_hr/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Project HR",
-    "version": "1.0",
+    "version": "1.1",
     "author": "AgroMarin",
     "summary": "Replace user assignees in project with HR employees",
     "description": """

--- a/addons/project_hr/migrations/1.1/post-migrate.py
+++ b/addons/project_hr/migrations/1.1/post-migrate.py
@@ -1,0 +1,82 @@
+"""Backfill resource.reservation rows for legacy project.task records (t20171).
+
+When ``resource.scheduling.mixin`` was introduced (t21163), its CRUD
+hooks created reservations on every create/write of project.task.
+Pre-existing tasks (with planned dates and assigned employees but no
+edits since the mixin landed) have no reservations, leaving
+``allocated_hours = 0`` after the t20171 PMI refactor (where
+``allocated_hours = sum(reservation_ids.allocated_hours)``).
+
+This migration triggers ``_sync_reservations()`` on every active task
+with the canonical scheduling triple (planned_date_begin + date_end +
+at least one employee_id) that does not yet have a reservation.  It
+processes in batches of 500 with intermediate commits so the upgrade
+transaction stays bounded.
+
+Idempotent: tasks that already have reservations are skipped by the
+SQL filter; running this migration twice is a no-op on the second run.
+
+Empirical scope at design time (marin190 production clone): 2250 tasks
+need backfill, ~2348 reservations to create.
+"""
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 500
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    cr.execute("""
+        SELECT pt.id
+        FROM project_task pt
+        WHERE pt.active = TRUE
+          AND pt.planned_date_begin IS NOT NULL
+          AND pt.date_end IS NOT NULL
+          AND EXISTS (
+              SELECT 1 FROM project_task_employee_rel rel
+              WHERE rel.task_id = pt.id
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM resource_reservation rr
+              WHERE rr.res_model = 'project.task'
+                AND rr.res_id = pt.id
+          )
+    """)
+    task_ids = [row[0] for row in cr.fetchall()]
+    total = len(task_ids)
+    if not total:
+        _logger.info("project_hr 1.1: no tasks need reservation backfill.")
+        return
+
+    _logger.info(
+        "project_hr 1.1: backfilling reservations for %d tasks "
+        "(batches of %d).",
+        total,
+        BATCH_SIZE,
+    )
+
+    Task = env["project.task"].with_context(active_test=False)
+    processed = 0
+    for offset in range(0, total, BATCH_SIZE):
+        batch_ids = task_ids[offset : offset + BATCH_SIZE]
+        batch = Task.browse(batch_ids).exists()
+        if batch:
+            batch._sync_reservations()
+        cr.commit()
+        processed += len(batch)
+        _logger.info(
+            "project_hr 1.1: %d / %d tasks processed.",
+            processed,
+            total,
+        )
+
+    _logger.info(
+        "project_hr 1.1: backfill complete (%d tasks).",
+        processed,
+    )

--- a/addons/project_hr/migrations/1.1/post-migrate.py
+++ b/addons/project_hr/migrations/1.1/post-migrate.py
@@ -61,7 +61,12 @@ def migrate(cr, version):
         BATCH_SIZE,
     )
 
-    Task = env["project.task"].with_context(active_test=False)
+    Task = env["project.task"].with_context(
+        active_test=False,
+        tracking_disable=True,
+        mail_notrack=True,
+        mail_create_nosubscribe=True,
+    )
     processed = 0
     for offset in range(0, total, BATCH_SIZE):
         batch_ids = task_ids[offset : offset + BATCH_SIZE]

--- a/addons/project_hr/tests/__init__.py
+++ b/addons/project_hr/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_reservation_sync

--- a/addons/project_hr/tests/test_reservation_sync.py
+++ b/addons/project_hr/tests/test_reservation_sync.py
@@ -1,0 +1,668 @@
+"""End-to-end tests for the project.task → resource.reservation sync flow.
+
+Exercises the canonical assignment path (``employee_ids`` from this
+module) wired through ``resource.scheduling.mixin``'s sync lifecycle
+and the PMI hours model (planned/allocated/unallocated).  Lives in
+core post-t20171: no enterprise dependency required.
+"""
+
+from datetime import datetime
+
+from odoo.fields import Command
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestReservationSync(TransactionCase):
+    """Verify the CRUD hooks on ``resource.scheduling.mixin`` drive the
+    reservation lifecycle end-to-end for ``project.task``.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Two companies: the "home" company the employee belongs to and a
+        # "foreign" company the editor might have active when editing.
+        cls.company_home = cls.env["res.company"].create(
+            {"name": "Home Co", "resource_calendar_id": False}
+        )
+        cls.company_foreign = cls.env["res.company"].create(
+            {"name": "Foreign Co", "resource_calendar_id": False}
+        )
+        # Pin attendance explicitly: in environments where the admin company's
+        # calendar carries a non-standard attendance pattern, default_get on
+        # ``resource.calendar`` would inherit it and break hour-count tests.
+        std_attendance = [
+            (
+                0,
+                0,
+                {
+                    "name": "Morning",
+                    "dayofweek": str(d),
+                    "hour_from": 8,
+                    "hour_to": 12,
+                    "day_period": "morning",
+                },
+            )
+            for d in range(5)
+        ] + [
+            (
+                0,
+                0,
+                {
+                    "name": "Afternoon",
+                    "dayofweek": str(d),
+                    "hour_from": 13,
+                    "hour_to": 17,
+                    "day_period": "afternoon",
+                },
+            )
+            for d in range(5)
+        ]
+        home_cal = cls.env["resource.calendar"].create(
+            {
+                "name": "Home 40h",
+                "tz": "UTC",
+                "company_id": cls.company_home.id,
+                "attendance_ids": std_attendance,
+            }
+        )
+        foreign_cal = cls.env["resource.calendar"].create(
+            {
+                "name": "Foreign 40h",
+                "tz": "UTC",
+                "company_id": cls.company_foreign.id,
+                "attendance_ids": std_attendance,
+            }
+        )
+        cls.company_home.resource_calendar_id = home_cal
+        cls.company_foreign.resource_calendar_id = foreign_cal
+
+        # tz=UTC on user/employee aligns the resource's timezone with the
+        # test calendars (also tz=UTC).  Otherwise the user inherits the
+        # admin company's tz (e.g. America/Mexico_City) and
+        # ``_get_valid_work_intervals`` interprets attendance hours in that
+        # zone — turning a UTC Mon 8-17 input into MX 02-11, intersecting
+        # only 3h of the 8-12 attendance.
+        cls.user_with_resource = cls.env["res.users"].create(
+            {
+                "name": "Home Worker",
+                "login": "home.worker@test",
+                "tz": "UTC",
+                "company_id": cls.company_home.id,
+                "company_ids": [
+                    Command.set([cls.company_home.id, cls.company_foreign.id])
+                ],
+                "group_ids": [
+                    Command.link(cls.env.ref("base.group_user").id),
+                    Command.link(cls.env.ref("project.group_project_user").id),
+                ],
+            }
+        )
+        cls.employee = cls.env["hr.employee"].create(
+            {
+                "name": "Home Worker",
+                "user_id": cls.user_with_resource.id,
+                "company_id": cls.company_home.id,
+                "tz": "UTC",
+            }
+        )
+
+        cls.project = cls.env["project.project"].create(
+            {"name": "Test Project", "company_id": cls.company_home.id}
+        )
+        cls.scheduled_vals = {
+            "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+            "date_end": datetime(2026, 5, 4, 17, 0),
+        }
+
+    # ------------------------------------------------------------------
+    # Create-time sync
+    # ------------------------------------------------------------------
+
+    def test_create_with_assignee_generates_reservation(self):
+        """Creating a scheduled task with an employee must generate exactly
+        one reservation for that employee's resource."""
+        task = self.env["project.task"].create(
+            {
+                "name": "Create + assignee",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                **self.scheduled_vals,
+            }
+        )
+        self.assertEqual(len(task.reservation_ids), 1)
+        self.assertEqual(task.reservation_ids.resource_id, self.employee.resource_id)
+
+    def test_create_without_dates_does_not_generate_reservation(self):
+        """No scheduling dates → no reservation even with assignees."""
+        task = self.env["project.task"].create(
+            {
+                "name": "Unscheduled",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+            }
+        )
+        self.assertFalse(task.reservation_ids)
+
+    # ------------------------------------------------------------------
+    # Write-time sync — the scenario the user hit in the UI
+    # ------------------------------------------------------------------
+
+    def test_adding_employee_to_existing_task_creates_reservation(self):
+        """Replicates the exact UI scenario that failed: a scheduled task
+        already exists, then the user assigns someone via write().
+        """
+        task = self.env["project.task"].create(
+            {
+                "name": "Existing task",
+                "project_id": self.project.id,
+                **self.scheduled_vals,
+            }
+        )
+        self.assertFalse(task.reservation_ids)
+
+        task.write({"employee_ids": [Command.link(self.employee.id)]})
+
+        self.assertEqual(
+            len(task.reservation_ids),
+            1,
+            "Adding an assignee with a resource must auto-create its reservation",
+        )
+        self.assertEqual(task.reservation_ids.resource_id, self.employee.resource_id)
+
+    def test_removing_employee_from_task_removes_its_reservation(self):
+        task = self.env["project.task"].create(
+            {
+                "name": "To be unassigned",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                **self.scheduled_vals,
+            }
+        )
+        self.assertEqual(len(task.reservation_ids), 1)
+
+        task.write({"employee_ids": [Command.unlink(self.employee.id)]})
+
+        self.assertFalse(
+            task.reservation_ids,
+            "Unassigning the last employee must clear the reservation",
+        )
+
+    def test_changing_dates_updates_reservation_range(self):
+        task = self.env["project.task"].create(
+            {
+                "name": "Reschedule me",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                **self.scheduled_vals,
+            }
+        )
+        reservation = task.reservation_ids
+        self.assertEqual(len(reservation), 1)
+        new_start = datetime(2026, 6, 1, 8, 0)
+        new_end = datetime(2026, 6, 1, 17, 0)
+
+        task.write({"planned_date_begin": new_start, "date_end": new_end})
+
+        self.assertEqual(reservation.date_start, new_start)
+        self.assertEqual(reservation.date_end, new_end)
+
+    def test_clearing_dates_removes_reservations(self):
+        task = self.env["project.task"].create(
+            {
+                "name": "Unschedule me",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                **self.scheduled_vals,
+            }
+        )
+        self.assertEqual(len(task.reservation_ids), 1)
+
+        task.write({"planned_date_begin": False, "date_end": False})
+
+        self.assertFalse(task.reservation_ids)
+
+    # ------------------------------------------------------------------
+    # Multi-company scenario
+    # ------------------------------------------------------------------
+
+    def test_assigning_employee_from_foreign_company_resolves_resource(self):
+        """Editing a task from a company different from the employee's home
+        must still resolve the resource — the lookup walks
+        ``employee.resource_id`` directly, which is already company-scoped.
+        """
+        task = self.env["project.task"].create(
+            {
+                "name": "Cross-company edit",
+                "project_id": self.project.id,
+                **self.scheduled_vals,
+            }
+        )
+        self.assertFalse(task.reservation_ids)
+
+        task.with_company(self.company_foreign).write(
+            {"employee_ids": [Command.link(self.employee.id)]}
+        )
+
+        self.assertEqual(len(task.reservation_ids), 1)
+        self.assertEqual(task.reservation_ids.resource_id, self.employee.resource_id)
+
+    def test_foreign_company_edit_preserves_existing_reservations(self):
+        """Touching a sync-trigger field from a foreign company context must
+        not destroy existing reservations whose employees belong elsewhere.
+        """
+        task = self.env["project.task"].create(
+            {
+                "name": "Keep me",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                **self.scheduled_vals,
+            }
+        )
+        reservation = task.reservation_ids
+        self.assertEqual(len(reservation), 1)
+
+        task.with_company(self.company_foreign).write({"allocated_percentage": 75.0})
+
+        self.assertTrue(
+            reservation.exists(),
+            "Existing reservations must survive foreign-company writes.",
+        )
+
+    # ------------------------------------------------------------------
+    # Multi-employee reconciliation
+    # ------------------------------------------------------------------
+
+    def _create_second_assignee(self):
+        """Helper: a second user/employee in the home company (tz=UTC)."""
+        user = self.env["res.users"].create(
+            {
+                "name": "Second Worker",
+                "login": "second.worker@test",
+                "tz": "UTC",
+                "company_id": self.company_home.id,
+                "company_ids": [Command.set([self.company_home.id])],
+                "group_ids": [
+                    Command.link(self.env.ref("base.group_user").id),
+                    Command.link(self.env.ref("project.group_project_user").id),
+                ],
+            }
+        )
+        employee = self.env["hr.employee"].create(
+            {
+                "name": "Second Worker",
+                "user_id": user.id,
+                "company_id": self.company_home.id,
+                "tz": "UTC",
+            }
+        )
+        return user, employee
+
+    def test_multi_employee_creates_one_reservation_each(self):
+        _, second_employee = self._create_second_assignee()
+        task = self.env["project.task"].create(
+            {
+                "name": "Multi-assigned",
+                "project_id": self.project.id,
+                "employee_ids": [Command.set([self.employee.id, second_employee.id])],
+                **self.scheduled_vals,
+            }
+        )
+        self.assertEqual(len(task.reservation_ids), 2)
+        self.assertEqual(
+            task.reservation_ids.mapped("resource_id").sorted("id"),
+            (self.employee.resource_id | second_employee.resource_id).sorted("id"),
+        )
+
+    def test_removing_one_of_several_employees_only_clears_its_reservation(self):
+        _, second_employee = self._create_second_assignee()
+        task = self.env["project.task"].create(
+            {
+                "name": "Multi then trim",
+                "project_id": self.project.id,
+                "employee_ids": [Command.set([self.employee.id, second_employee.id])],
+                **self.scheduled_vals,
+            }
+        )
+        self.assertEqual(len(task.reservation_ids), 2)
+
+        task.write({"employee_ids": [Command.unlink(self.employee.id)]})
+
+        self.assertEqual(len(task.reservation_ids), 1)
+        self.assertEqual(task.reservation_ids.resource_id, second_employee.resource_id)
+
+    # ------------------------------------------------------------------
+    # Archive / unarchive mirror
+    # ------------------------------------------------------------------
+
+    def test_archiving_task_archives_its_reservations(self):
+        task = self.env["project.task"].create(
+            {
+                "name": "Archive me",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                **self.scheduled_vals,
+            }
+        )
+        reservation_id = task.reservation_ids.id
+        reservation_no_filter = (
+            self.env["resource.reservation"]
+            .with_context(active_test=False)
+            .browse(reservation_id)
+        )
+
+        task.action_archive()
+
+        self.assertFalse(reservation_no_filter.active)
+        self.assertFalse(
+            task.reservation_ids,
+            "Archived reservations must drop out of the default O2M.",
+        )
+
+    def test_unarchiving_task_restores_its_reservations(self):
+        task = self.env["project.task"].create(
+            {
+                "name": "Roundtrip",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                **self.scheduled_vals,
+            }
+        )
+        task.action_archive()
+        task.action_unarchive()
+
+        self.assertEqual(
+            len(task.reservation_ids),
+            1,
+            "Restoring the task must surface its reservation again.",
+        )
+        self.assertTrue(task.reservation_ids.active)
+
+    # ------------------------------------------------------------------
+    # ``user_ids`` is read-only in this fork — guarantee the silent no-op
+    # ------------------------------------------------------------------
+
+    def test_writing_user_ids_is_silently_ignored(self):
+        """``user_ids`` is a stored compute mirror of ``employee_ids``.
+
+        ``readonly=True`` on the field makes the ORM drop direct writes
+        on the floor — this test pins that behavior so a future change
+        (e.g. someone adding ``inverse=`` again) is caught immediately.
+        Callers that intend to assign someone must write ``employee_ids``.
+        """
+        task = self.env["project.task"].create(
+            {
+                "name": "user_ids no-op",
+                "project_id": self.project.id,
+                **self.scheduled_vals,
+            }
+        )
+        self.assertFalse(task.employee_ids)
+        self.assertFalse(task.user_ids)
+
+        task.write({"user_ids": [Command.link(self.user_with_resource.id)]})
+
+        self.assertFalse(
+            task.employee_ids,
+            "user_ids is read-only — writes must not propagate to employee_ids.",
+        )
+        self.assertFalse(task.reservation_ids)
+
+    # ------------------------------------------------------------------
+    # ``hr.employee.resource_id`` change propagates to reservations
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # PMI hours model (t20171): planned / allocated / unallocated
+    # ------------------------------------------------------------------
+
+    def test_planned_hours_default_from_range(self):
+        """``planned_hours`` auto-computes from the task's date range using
+        the company calendar (Mon-Fri 8h/day).
+        """
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Planned default",
+                "project_id": self.project.id,
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        self.assertEqual(task.planned_hours, 8.0)
+
+    def test_planned_hours_user_override_persists(self):
+        """User-set ``planned_hours`` overrides the auto-compute."""
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Planned override",
+                "project_id": self.project.id,
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+                "planned_hours": 20.0,
+            }
+        )
+        self.assertEqual(task.planned_hours, 20.0)
+
+    def test_allocated_hours_single_user_sums_one_reservation(self):
+        """1 user with custom calendar → 1 reservation → allocated = its hours."""
+        half_calendar = self.env["resource.calendar"].create(
+            {
+                "name": "Half Day",
+                "tz": "UTC",
+                "company_id": self.company_home.id,
+                "attendance_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Mon AM",
+                            "dayofweek": "0",
+                            "hour_from": 8,
+                            "hour_to": 12,
+                            "day_period": "morning",
+                        },
+                    )
+                ],
+            }
+        )
+        self.employee.resource_calendar_id = half_calendar
+        task = self.env["project.task"].create(
+            {
+                "name": "Half day single user",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        # 1 reservation with the user's half calendar → 4h
+        self.assertEqual(len(task.reservation_ids), 1)
+        self.assertEqual(task.allocated_hours, 4.0)
+
+    def test_allocated_hours_multi_user_sums_reservations(self):
+        """≥2 users → N reservations (one per employee) → allocated_hours
+        is the SUM (PMI Work semantic: person-hours across resources).
+        """
+        _, second_employee = self._create_second_assignee()
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Multi user",
+                "project_id": self.project.id,
+                "employee_ids": [
+                    Command.set([self.employee.id, second_employee.id])
+                ],
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        self.assertEqual(len(task.reservation_ids), 2)
+        # Each reservation: Mon 8-17 = 8h. Sum = 16h.
+        self.assertEqual(task.allocated_hours, 16.0)
+
+    def test_allocated_hours_zero_user_returns_zero(self):
+        """0 users → 0 reservations → allocated_hours = 0.
+
+        Honest signal: no resource is committed.  ``planned_hours``
+        keeps the estimate so dashboards retain planning information.
+        """
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "No assignee",
+                "project_id": self.project.id,
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        self.assertFalse(task.employee_ids)
+        self.assertEqual(task.allocated_hours, 0.0)
+        self.assertEqual(task.planned_hours, 8.0)
+        self.assertEqual(task.unallocated_hours, 8.0)
+
+    def test_allocated_hours_scales_by_allocated_percentage(self):
+        """``allocated_percentage=50`` over 8 effective hours → 4h reservation
+        → 4h allocated.  Pin: percentage flows through the reservation.
+        """
+        task = self.env["project.task"].create(
+            {
+                "name": "50%",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+                "allocated_percentage": 50.0,
+            }
+        )
+        self.assertEqual(task.allocated_hours, 4.0)
+
+    def test_planned_resources_default_one(self):
+        """Default ``planned_resources`` = 1; planned_hours = scheduled_hours."""
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Default resources",
+                "project_id": self.project.id,
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        self.assertEqual(task.planned_resources, 1)
+        self.assertEqual(task.scheduled_hours, 8.0)
+        self.assertEqual(task.planned_hours, 8.0)
+
+    def test_planned_resources_doubles_planned_hours(self):
+        """Setting ``planned_resources=2`` doubles planned_hours."""
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Two resources",
+                "project_id": self.project.id,
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+                "planned_resources": 2,
+            }
+        )
+        self.assertEqual(task.scheduled_hours, 8.0)
+        self.assertEqual(task.planned_hours, 16.0)
+
+    def test_allocation_state_unestimated(self):
+        """No dates, no resources → unestimated."""
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {"name": "No dates", "project_id": self.project.id}
+        )
+        self.assertEqual(task.allocation_state, "unestimated")
+
+    def test_allocation_state_unallocated(self):
+        """Dates but no employees → unallocated (intent without commit)."""
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Not assigned",
+                "project_id": self.project.id,
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        self.assertEqual(task.planned_hours, 8.0)
+        self.assertEqual(task.allocated_hours, 0.0)
+        self.assertEqual(task.allocation_state, "unallocated")
+
+    def test_allocation_state_allocated(self):
+        """planned_resources=1 + 1 employee → allocated (matches intent)."""
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Allocated",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        self.assertEqual(task.planned_hours, 8.0)
+        self.assertEqual(task.allocated_hours, 8.0)
+        self.assertEqual(task.allocation_state, "allocated")
+
+    def test_allocation_state_under_allocated(self):
+        """planned_resources=2, 1 employee → under_allocated."""
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Partial",
+                "project_id": self.project.id,
+                "planned_resources": 2,
+                "employee_ids": [Command.link(self.employee.id)],
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        self.assertEqual(task.planned_hours, 16.0)
+        self.assertEqual(task.allocated_hours, 8.0)
+        self.assertEqual(task.allocation_state, "under_allocated")
+
+    def test_allocation_state_over_allocated(self):
+        """planned_resources=1 (default), 2 employees → over_allocated (PM over-allocated)."""
+        _, second_employee = self._create_second_assignee()
+        task = self.env["project.task"].with_company(self.company_home).create(
+            {
+                "name": "Overplanned",
+                "project_id": self.project.id,
+                "employee_ids": [
+                    Command.set([self.employee.id, second_employee.id])
+                ],
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        self.assertEqual(task.planned_hours, 8.0)
+        self.assertEqual(task.allocated_hours, 16.0)
+        self.assertEqual(task.allocation_state, "over_allocated")
+
+    def test_changing_employee_resource_updates_existing_reservations(self):
+        task = self.env["project.task"].create(
+            {
+                "name": "Resource swap",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                **self.scheduled_vals,
+            }
+        )
+        original_resource = self.employee.resource_id
+        self.assertEqual(task.reservation_ids.resource_id, original_resource)
+
+        replacement = self.env["resource.resource"].create(
+            {
+                "name": "Replacement Resource",
+                "calendar_id": self.company_home.resource_calendar_id.id,
+                "company_id": self.company_home.id,
+            }
+        )
+        self.employee.resource_id = replacement
+
+        self.assertEqual(
+            len(task.reservation_ids),
+            1,
+            "Swapping the employee's resource must not duplicate reservations.",
+        )
+        self.assertEqual(
+            task.reservation_ids.resource_id,
+            replacement,
+            "The reservation must follow the employee's current resource.",
+        )

--- a/addons/project_hr/tests/test_reservation_sync.py
+++ b/addons/project_hr/tests/test_reservation_sync.py
@@ -8,9 +8,12 @@ core post-t20171: no enterprise dependency required.
 
 from datetime import datetime
 
+from psycopg import IntegrityError
+
 from odoo.fields import Command
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
+from odoo.tools import mute_logger
 
 
 @tagged("post_install", "-at_install")
@@ -519,7 +522,7 @@ class TestReservationSync(TransactionCase):
         self.assertFalse(task.employee_ids)
         self.assertEqual(task.allocated_hours, 0.0)
         self.assertEqual(task.planned_hours, 8.0)
-        self.assertEqual(task.unallocated_hours, 8.0)
+        self.assertEqual(task.allocation_state, "unallocated")
 
     def test_allocated_hours_scales_by_allocated_percentage(self):
         """``allocated_percentage=50`` over 8 effective hours → 4h reservation
@@ -536,6 +539,29 @@ class TestReservationSync(TransactionCase):
             }
         )
         self.assertEqual(task.allocated_hours, 4.0)
+
+    def test_planned_hours_honors_allocated_percentage(self):
+        """PMBOK Effort = Duration x Resources x Units.
+
+        ``allocated_percentage=50`` halves planned_hours so allocation_state
+        reflects intent honestly: planning at half-time and committing at
+        half-time should land on ``allocated``, not ``under_allocated``.
+        """
+        task = self.env["project.task"].create(
+            {
+                "name": "Half-time plan",
+                "project_id": self.project.id,
+                "employee_ids": [Command.link(self.employee.id)],
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+                "allocated_percentage": 50.0,
+            }
+        )
+        self.assertEqual(task.scheduled_hours, 8.0)
+        self.assertEqual(task.planned_resources, 1)
+        self.assertEqual(task.planned_hours, 4.0)
+        self.assertEqual(task.allocated_hours, 4.0)
+        self.assertEqual(task.allocation_state, "allocated")
 
     def test_planned_resources_default_one(self):
         """Default ``planned_resources`` = 1; planned_hours = scheduled_hours."""
@@ -564,6 +590,84 @@ class TestReservationSync(TransactionCase):
         )
         self.assertEqual(task.scheduled_hours, 8.0)
         self.assertEqual(task.planned_hours, 16.0)
+
+    def test_planned_resources_must_be_positive(self):
+        """DB-level CHECK rejects planned_resources <= 0."""
+        with (
+            self.assertRaises(IntegrityError),
+            self.cr.savepoint(),
+            mute_logger("odoo.db"),
+        ):
+            self.env["project.task"].create(
+                {
+                    "name": "Zero resources",
+                    "project_id": self.project.id,
+                    "planned_resources": 0,
+                }
+            )
+
+        with (
+            self.assertRaises(IntegrityError),
+            self.cr.savepoint(),
+            mute_logger("odoo.db"),
+        ):
+            self.env["project.task"].create(
+                {
+                    "name": "Negative resources",
+                    "project_id": self.project.id,
+                    "planned_resources": -1,
+                }
+            )
+
+    def test_planned_hours_inverse_posts_on_manual_override(self):
+        """Direct user write of planned_hours posts a chatter message.
+
+        Stored compute recomputes (triggered by scheduled_hours or
+        planned_resources changes) MUST NOT post; only direct writes do.
+        """
+        task = self.env["project.task"].create(
+            {
+                "name": "Override case",
+                "project_id": self.project.id,
+                "planned_date_begin": datetime(2026, 5, 4, 8, 0),
+                "date_end": datetime(2026, 5, 4, 17, 0),
+            }
+        )
+        baseline = self.env["mail.message"].search_count(
+            [("res_id", "=", task.id), ("model", "=", "project.task")]
+        )
+
+        # Dependency-driven recompute: must NOT post.
+        task.write({"planned_resources": 2})
+        self.assertEqual(task.planned_hours, 16.0)
+        after_recompute = self.env["mail.message"].search_count(
+            [("res_id", "=", task.id), ("model", "=", "project.task")]
+        )
+        recompute_messages = after_recompute - baseline
+        # planned_resources is tracked → 1 message expected, but it must
+        # not also include a planned_hours override entry.
+        override_msgs = self.env["mail.message"].search(
+            [
+                ("res_id", "=", task.id),
+                ("model", "=", "project.task"),
+                ("body", "ilike", "manually overridden"),
+            ]
+        )
+        self.assertFalse(
+            override_msgs,
+            "Recompute should not trigger override message.",
+        )
+
+        # Direct user write: must post override message.
+        task.write({"planned_hours": 99.0})
+        override_msgs = self.env["mail.message"].search(
+            [
+                ("res_id", "=", task.id),
+                ("model", "=", "project.task"),
+                ("body", "ilike", "manually overridden"),
+            ]
+        )
+        self.assertEqual(len(override_msgs), 1)
 
     def test_allocation_state_unestimated(self):
         """No dates, no resources → unestimated."""

--- a/addons/resource/models/resource_scheduling_mixin.py
+++ b/addons/resource/models/resource_scheduling_mixin.py
@@ -166,23 +166,7 @@ class ResourceSchedulingMixin(models.AbstractModel):
 
     @api.depends("reservation_ids.allocated_hours")
     def _compute_allocated_hours(self):
-        """Aggregate committed hours from the canonical reservation ledger.
-
-        ``resource.reservation`` owns the per-record calendar-aware
-        computation (see ``resource_reservation._compute_allocated_hours``).
-        The mixin sums those values across the consumer's reservations.
-
-        Multi-resource consumers report the PMI Work semantic
-        (person-hours of effort committed): a task with two assignees over
-        the same range yields ``2x range_work_hours``.  This is intentional
-        - see ``project.task.unallocated_hours`` for the gap between
-        ``planned_hours`` (estimate) and ``allocated_hours`` (committed).
-
-        Consumers without reservations report ``0.0`` honestly: no
-        commitment yet.  The estimate of effort lives in
-        ``planned_hours`` on the consumer (when the consumer declares it),
-        not here.
-        """
+        """Aggregate committed hours from the consumer's reservation ledger."""
         for record in self:
             record.allocated_hours = sum(
                 record.reservation_ids.mapped("allocated_hours")

--- a/addons/resource/models/resource_scheduling_mixin.py
+++ b/addons/resource/models/resource_scheduling_mixin.py
@@ -11,8 +11,10 @@ class ResourceSchedulingMixin(models.AbstractModel):
 
     Provides:
     - Reverse One2many to ``resource.reservation`` via ``(res_model, res_id)``
-    - Shared ``allocated_percentage`` + computed ``allocated_hours``
-      and ``schedule_overlap_count``
+    - Shared ``allocated_percentage`` (input passed through to reservations)
+    - Computed ``allocated_hours`` aggregated from ``reservation_ids``
+      (PMI Work semantic: sum of person-hours committed across resources)
+    - Computed ``schedule_overlap_count`` aggregated from reservations
     - CRUD hooks that reconcile reservations via ``_sync_reservations``
     - Contracts consumers override: ``_get_reservation_date_fields``,
       ``_get_reservation_vals_list``, ``_get_sync_trigger_fields``
@@ -21,10 +23,10 @@ class ResourceSchedulingMixin(models.AbstractModel):
       ``_scheduling_resolve_calendar``) for calendar-aware computations
       independent of field-name conventions
 
-    Scheduling data fields (date_start, date_end, resource_id,
-    resource_calendar_id) live on ``resource.reservation`` itself — consumer
-    models expose their own date fields via ``_get_reservation_date_fields``
-    and build sync payloads via ``_get_reservation_vals_list``.
+    Consumers that need a planning estimate independent of resource
+    commitment (e.g. ``project.task.planned_hours``) declare it locally;
+    the mixin only computes the *committed* side.  See PMI hours model in
+    ``knowledge/agromarin-knowledge/reference/business/pmi-hours-model.md``.
     """
 
     _name = "resource.scheduling.mixin"
@@ -162,42 +164,29 @@ class ResourceSchedulingMixin(models.AbstractModel):
     # Generic computes
     # ------------------------------------------------------------------
 
+    @api.depends("reservation_ids.allocated_hours")
     def _compute_allocated_hours(self):
-        """Compute working hours from the consumer's date fields.
+        """Aggregate committed hours from the canonical reservation ledger.
 
-        When ``_get_reservation_date_fields`` returns ``(None, None)`` the
-        consumer is not calendar-aware at the core level; preserve any
-        manually entered value rather than overwriting it with zero.
+        ``resource.reservation`` owns the per-record calendar-aware
+        computation (see ``resource_reservation._compute_allocated_hours``).
+        The mixin sums those values across the consumer's reservations.
 
-        Consumers with real date fields typically override this with a
-        domain-specific compute (e.g. ``project_enterprise`` uses
-        ``planned_date_begin`` / ``date_end`` + assignee calendars).
+        Multi-resource consumers report the PMI Work semantic
+        (person-hours of effort committed): a task with two assignees over
+        the same range yields ``2x range_work_hours``.  This is intentional
+        - see ``project.task.unallocated_hours`` for the gap between
+        ``planned_hours`` (estimate) and ``allocated_hours`` (committed).
+
+        Consumers without reservations report ``0.0`` honestly: no
+        commitment yet.  The estimate of effort lives in
+        ``planned_hours`` on the consumer (when the consumer declares it),
+        not here.
         """
         for record in self:
-            start_field, end_field = record._get_reservation_date_fields()
-            if not start_field or not end_field:
-                # No scheduling fields: keep the manual value (the field is
-                # stored + readonly=False, so direct writes already persist).
-                continue
-            date_start = record[start_field]
-            date_end = record[end_field]
-            if not date_start or not date_end:
-                record.allocated_hours = 0.0
-                continue
-            resource = record.resource_id if "resource_id" in record._fields else None
-            calendar = (
-                record.resource_calendar_id
-                if "resource_calendar_id" in record._fields
-                else None
+            record.allocated_hours = sum(
+                record.reservation_ids.mapped("allocated_hours")
             )
-            work_hours = record._scheduling_get_work_hours(
-                date_start,
-                date_end,
-                resource=resource,
-                calendar=calendar,
-            )
-            pct = record.allocated_percentage
-            record.allocated_hours = round(work_hours * pct / 100.0, 2)
 
     @api.depends("reservation_ids.schedule_overlap_count")
     def _compute_schedule_overlap_count(self):


### PR DESCRIPTION
# [Task ID: t20171](https://agromarin.mx/odoo/project.task/20171)

## Problem

`project.task.allocated_hours` is overloaded with two PMI/PMBOK semantics:
- **Effort estimate** (Work) — what dashboards like sprint, baseline, history snapshot as `planned_hours`.
- **Resource commitment** (Allocation) — what capacity reports want to read.

The duplicated `_compute_allocated_hours` logic between `resource.scheduling.mixin` and `resource.reservation` is a symptom: each consumer reaches for the field expecting different semantics, and nobody can give both honest answers from a single overloaded column.

Layer integrity is also broken: `planned_date_begin` (PMI Constraint Start) lives in `enterprise/project_enterprise` while `date_end` (Constraint End) lives in core, leaving `project.task` asymmetric and forcing the mixin into awkward coupling with enterprise.

## Solution

### PMI three-tier hours model on `project.task`

Following PMI/PMBOK's `Effort = Duration × Resources`:

| Field | Type | Meaning | PMBOK term |
|---|---|---|---|
| `scheduled_hours` | Float (compute, store) | Working hours within the date range, against the company calendar | Activity Duration in working time units |
| `planned_resources` | Integer (default=1, tracking) | PM intent: parallel resources expected | Planned resource units |
| `planned_hours` | Float (compute = scheduled × planned_resources, override permitted, tracking) | Total effort estimate | Activity Effort / Work |
| `allocated_hours` | Float (sum aggregation via mixin, tracking) | Hours committed across all assigned resources | Resource Assignment Work |

### Allocation health signal

`allocation_state` (Selection, compute, store) — 5 states mirroring the `invoice_state` pattern on `sale.order`:

| State | Meaning |
|---|---|
| `unestimated` | No `planned_hours` yet (no dates / no resources). |
| `unallocated` | Has estimate but no employees committed. |
| `under_allocated` | Some commitment but less than estimate. |
| `allocated` | Commitment matches estimate (within tolerance). |
| `over_allocated` | Commitment exceeds estimate (PM over-allocated). |

Vocabulary aligned with MS Project's "Over-Allocated" warning indicator.

**Premise**: `planned_resources` is **intent** (how many resources the PM plans for); `employee_ids` is **commitment** (who is actually assigned). Each employee generates one reservation; no cap. The intent vs commit discrepancy is materialized in `allocation_state` — `over_allocated` when employees > planned_resources, `under_allocated` when employees < planned_resources.

### Layer integrity restored

`planned_date_begin` and its primitives move from `enterprise/project_enterprise` to `core/addons/project`:
- Field declaration with `tracking=True`.
- `_planned_dates_check` constraint.
- `_onchange_planned_dates`, `action_unschedule_task`.
- `_calculate_planned_dates` utility (calendar-aware date snapping).
- `_get_reservation_date_fields` returning `("planned_date_begin", "date_end")`.

`project.task` is now schedulable without enterprise; `enterprise/project_enterprise` becomes a pure gantt UI module.

### Mixin reduces to aggregation

`resource.scheduling.mixin._compute_allocated_hours` becomes a 5-line sum:

```python
@api.depends("reservation_ids.allocated_hours")
def _compute_allocated_hours(self):
    for record in self:
        record.allocated_hours = sum(record.reservation_ids.mapped("allocated_hours"))
```

The earlier scaffolding hooks (`_get_normalized_dates`, `_get_scheduling_resource`) are dropped — they were stepping stones to this final design.

## Downstream consumers wired per PMI semantics

| Consumer | Reads | Reason |
|---|---|---|
| `sprint.committed_hours` / `velocity` | `planned` | Scope baseline at sprint start |
| Burndown chart | `planned` | Scope baseline burn |
| `subtask_planned_hours` (renamed from `subtask_allocated_hours`) | `planned` | Estimate roll-up |
| `cd3_score` | `planned` | Estimate-based prioritization |
| `capacity_warning` (>40h/week) | `allocated` (via reservations) | Real per-resource commitment |
| `project.resource.report` | `allocated` (via reservations) | Real per-resource utilization |
| Portal customer view | `planned` | Estimate visible to customer |
| Timesheet `progress`, `remaining_hours`, `overtime` | `planned` | Vs `effective_hours` |
| `project.baseline`, `project.history` snapshots | `planned` | Scope baseline history |

## Migrations

### `project 1.7` (pre-migrate)

Adds `scheduled_hours`, `planned_resources` (default=1), `allocation_state`, `planned_hours` columns. Backfills `planned_hours = allocated_hours` to preserve dashboards reading the legacy field as estimate. Drops `unallocated_hours` column from earlier draft. Idempotent.

### `project_hr 1.1` (post-migrate)

Backfills `_sync_reservations()` for all active tasks with dates + employees but no reservations. Closes a data-integrity gap from t21163 (when the mixin lifecycle was introduced without a historical-data sync). Batches of 500 with intermediate commits.

**Empirical scope (marin190 production clone)**: 2348 reservations created across 2250 legacy tasks. Total reservations 483 → 2831, distinct synced tasks 434 → 2684.

## Verification

- `addons/project_hr/tests/test_reservation_sync.py` (moved from `enterprise/project_enterprise_hr`): **23 tests** (16 sync lifecycle + 7 PMI hours model + state transitions). All green on marin190 clone.
- Migration `project 1.7`: 12480 tasks with `planned_hours` preserved.
- Migration `project_hr 1.1`: 2348 reservations created, 0 tasks pending backfill post-migration.
- `ruff check` clean on changed files.
- Schema, field registry, view references, constraint all verified via psql against marin190 clone.

## Behavioral changes (intentional, communicate to PMO)

1. **Multi-user tasks**: `allocated_hours` now sum-aggregates across resources (8h × 2 employees = 16h person-hours per PMI Work). Dashboards reading `allocated` show inflated numbers; dashboards reading `planned` (most) keep showing the estimate unchanged.
2. **Tasks without assignees**: `allocated_hours = 0` until a resource is committed (was: range × calendar fallback). Strategic objectives preserve their `planned_hours` from migration; `allocation_state = unallocated`.
3. **`compute_leaves` flip**: Lunch hours stop counting as work via the new path. ~12-13% reduction visible on long-horizon multi-day tasks.

## Naming collision documented (technical debt, out of scope)

`planned_date_start` collides between core (CPM-intent stub) and enterprise (calendar widget alias). Kwargs merge correctly at runtime. Cleanup deferred to future task: rename core's CPM stub to `cpm_start_date` / `cpm_end_date`.

See `knowledge/agromarin-knowledge/reference/business/pmi-hours-model.md` for the canonical PMI hours model documentation.

## Companion PR

[maringuadarrama/enterprise#30](https://github.com/maringuadarrama/enterprise/pull/30) — drops the primitives moved to core; keeps gantt UI / visualization in enterprise.