### PR TITLE
[FIX] website_slides: drop stale ('remove', emoji_data.js) directive

### DIFF
--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -139,7 +139,14 @@ Featuring
             'website/static/src/libs/zoomodoo/zoomodoo.js',
             'web/static/src/core/**/*.js',
             'web/static/src/env.js',
-            ('remove', 'web/static/src/components/emoji_picker/emoji_data.js'),
+            # emoji_data.js was moved from web/static/src/core/emoji_picker/
+            # to web/static/src/components/emoji_picker/ during the ESM
+            # migration. The 'core/**/*.js' glob above no longer pulls it
+            # in, so the previous ('remove', ...) entry was orphaned and
+            # crashed _pregenerate_assets_bundles with ValueError. The
+            # exclusion intent (keep this minimal embed bundle small) is
+            # already satisfied by the new path layout — no replacement
+            # needed.
 
             'website_slides/static/src/scss/website_slides.scss',
             'website_slides/static/lib/pdfslidesviewer/PDFSlidesViewer.js',


### PR DESCRIPTION
# [Task ID: 21340](https://agromarin.mx/odoo/project.task/21340)

## Problem

The `slide_embed_assets` bundle in `website_slides` crashes `_pregenerate_assets_bundles` (`ir_qweb.py:4291`) with:

```
ValueError: File(s) ['/web/static/src/components/emoji_picker/emoji_data.js']
not found in bundle website_slides.slide_embed_assets
```

The crash fires at registry init when CI postload pre-generates asset bundles, blocking PR CI on databases pre-loaded with custom data (`template_ci.sql` / `marin190` clones).

## Root cause

In `addons/website_slides/__manifest__.py:140-142` the bundle uses the classic "include glob + remove one file" pattern:

```python
'web/static/src/core/**/*.js',
'web/static/src/env.js',
('remove', 'web/static/src/components/emoji_picker/emoji_data.js'),
```

The inclusion glob is `core/**`, but the `('remove', ...)` target is in `components/**`. The file **never entered the bundle** because the glob does not cover `components/`. Odoo's `('remove', X)` handler raises `ValueError` when X is absent instead of treating it as a NOOP.

**How it got this way**: during the ESM migration (commit `fdad91a872c5`, 2026-04-08) `emoji_picker/` was moved from `web/static/src/core/` to `web/static/src/components/`. The path inside the `('remove', ...)` directive was updated to match the new location, but the adjacent inclusion glob was left untouched as `core/**`. The remove was orphaned from that point on, and the only reason it did not crash earlier is that postload bundle pre-generation is gated to specific scenarios.

This is the same pattern documented internally as "obsolete `('remove', X)` directives become NOOPs (or crashes) when the fork moves the file out of the upstream folder".

## Solution

Drop the orphaned `('remove', ...)` directive and replace it with a comment explaining the ESM-migration history so future contributors do not re-add it.

```diff
   'web/static/src/core/**/*.js',
   'web/static/src/env.js',
-  ('remove', 'web/static/src/components/emoji_picker/emoji_data.js'),
+  # emoji_data.js was moved from web/static/src/core/emoji_picker/
+  # to web/static/src/components/emoji_picker/ during the ESM
+  # migration. The 'core/**/*.js' glob above no longer pulls it
+  # in, so the previous ('remove', ...) entry was orphaned and
+  # crashed _pregenerate_assets_bundles with ValueError. The
+  # exclusion intent (keep this minimal embed bundle small) is
+  # already satisfied by the new path layout — no replacement
+  # needed.
```

Behaviour is identical: `emoji_data.js` stays out of `slide_embed_assets` because the inclusion glob never covered `components/`. The standalone `web.assets_emoji` bundle (loaded lazily by `emoji_picker.js` on hover) is unaffected.

## Verification

| Scenario | Result |
|---|---|
| Registry init with bundle pre-generation **without** the fix | ❌ `ValueError: File(s) [...emoji_data.js] not found in bundle website_slides.slide_embed_assets` |
| Same scenario **with** the fix | ✅ Postload completes, bundles generate cleanly |
| Diff of generated `slide_embed_assets` bundle before vs after | identical (emoji_data.js was never included) |

## Related

This is the fifth and final blocker discovered after merging:

- [t21290](https://agromarin.mx/odoo/project.task/21290) — `date_range` `FakeModelLoader.restore_registry` (MERGED)
- [t21297](https://agromarin.mx/odoo/project.task/21297) — `geoengine_l10n_mx` `psycopg2` (MERGED)
- [t21300](https://agromarin.mx/odoo/project.task/21300) — `l10n_mx_edi` dead `odoo.tools.zeep` patch (MERGED)
- [t21330](https://agromarin.mx/odoo/project.task/21330) — `orm` `get_column_update` stale flat cache guard (MERGED, PR #142)
- [t18043](https://agromarin.mx/odoo/project.task/18043) — S3 filestore (blocked by this issue) — set as `predecessor_ids`