### PR TITLE
[FIX] mail: decrement inbox counter on optimistic mark-as-read

### DIFF
--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -719,10 +719,12 @@ export class Message extends Record {
 
     async setDone() {
         // Optimistic UI update: immediately mark as read so the notification
-        // disappears without waiting for the bus notification.
+        // disappears and the systray counter decreases without waiting for
+        // the bus notification.
         if (this.needaction) {
             this.needaction = false;
             this.store.inbox.messages.delete(this);
+            this.store.inbox.counter--;
             if (this.thread) {
                 this.thread.message_needaction_counter--;
             }


### PR DESCRIPTION
# [Task ID: 22090](https://agromarin.mx/odoo/project.task/22090)

## Problem

When the user clicks the read checkmark (✓) on a single notification in the systray messaging menu, the message disappears from the list but the badge counter ("globito") stays at the previous value until the page is reloaded.

Reported by Jem (Sistemas) with screenshots showing the inbox dropping a notification while the badge remained at `1002`.

## Diagnosis

The bug is in `addons/mail/static/src/core/common/message_model.js`, method `Message.setDone()`. The optimistic UI update is incomplete:

- ✅ Sets `this.needaction = false`
- ✅ Removes the message from `store.inbox.messages`
- ✅ Decrements `thread.message_needaction_counter`
- ❌ **Does not decrement `store.inbox.counter`**

The systray badge is rendered by `MessagingMenu` (`addons/mail/static/src/core/web/messaging_menu_patch.js:185-199`) using `store.globalCounter`, a `fields.Attr` whose compute reads `inbox.counter`. The compute and the OWL re-render chain work correctly — verified empirically by forcing `store.inbox.counter = 999`, which updated the badge to `1001` (35 real + `canPromptToInstall` + `shouldAskPushPermission`) without reloading.

Backend `mail.message.set_message_done()` then emits `mail.message/mark_as_read` with `needaction_inbox_counter`. The handler in `mail_core_web_service.js:65-103` assigns `inbox.counter = needaction_inbox_counter`, but only when `notifId > inbox.counter_bus_id`. After repeated mark-as-read events, `counter_bus_id` advances, and subsequent bus events can fail this guard depending on the order in which the bus dispatches notifications — leaving the badge stale.

## Solution

Add a single optimistic decrement to `setDone()`, mirroring the existing thread-counter decrement:

```js
async setDone() {
    if (this.needaction) {
        this.needaction = false;
        this.store.inbox.messages.delete(this);
        this.store.inbox.counter--;                       // ← new
        if (this.thread) {
            this.thread.message_needaction_counter--;
        }
    }
    await this.store.env.services.orm.silent.call(
        "mail.message", "set_message_done", [[this.id]],
    );
}
```

The badge now updates immediately on click. If the bus event arrives afterwards with a different `needaction_inbox_counter`, the existing handler reassigns the value, so any drift between client and server is self-correcting on the next bus message.

## Verification

- Manual: reload the page, click the read checkmark on a notification → badge decrements without reload. Confirmed by Jem.
- Regression risk: low — the change adds a decrement to an existing optimistic block; the subsequent bus event still synchronizes from the server.
- No tests modified (no existing tests cover `setDone` counter behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)