### PR TITLE
[FIX] core/service: remove RLIMIT_AS to fix gevent worker zombie

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -60,7 +60,6 @@ except ImportError:
         return None
 
 
-import odoo
 from odoo import api, db
 from odoo.libs import gc
 from odoo.libs.filesystem import osutil
@@ -82,7 +81,6 @@ _logger = logging.getLogger(__name__)
 SLEEP_INTERVAL = 60  # 1 min
 
 
-
 def memory_info(process: Any) -> int:
     """Return the resident memory (RSS) of the process in bytes.
 
@@ -95,16 +93,24 @@ def memory_info(process: Any) -> int:
 
 
 def set_limit_memory_hard() -> None:
-    """Set RLIMIT_AS to the configured hard memory limit for the current process."""
-    if platform.system() != "Linux":
-        return
-    limit_memory_hard = config["limit_memory_hard"]
-    if odoo.evented and config["limit_memory_hard_gevent"]:
-        limit_memory_hard = config["limit_memory_hard_gevent"]
-    if limit_memory_hard:
-        rlimit = resource.RLIMIT_AS
-        _soft, hard = resource.getrlimit(rlimit)
-        resource.setrlimit(rlimit, (limit_memory_hard, hard))
+    """Deprecated: no-op.
+
+    Earlier versions applied ``RLIMIT_AS`` (virtual address space) to the
+    current process. That is incompatible with modern Python on Linux: the
+    new allocator and gevent fiber pools reserve multi-GB ranges of virtual
+    space that never become resident, so the worker reaches its ``RLIMIT_AS``
+    cap and is denied ``pthread_create`` long before any real memory pressure
+    exists. Meanwhile :func:`process_limit` measures real memory and never
+    triggers the orderly recycle path, leaving the worker zombie.
+
+    Memory control is now entirely handled by :func:`process_limit` via
+    :func:`memory_info` (RSS). The hard cap that previously came from the
+    kernel ``RLIMIT_AS`` should be enforced externally -- the recommended
+    backstop is a cgroup v2 limit on the ``odoo.service`` systemd unit
+    (``MemoryMax=`` + ``MemorySwapMax=0``), which kills the worst offender
+    cleanly if Odoo ever fails to recycle in time.
+    """
+    return
 
 
 def empty_pipe(fd: int) -> None:
@@ -697,7 +703,6 @@ class ThreadedServer(CommonServer):
 
     def start(self, stop: bool = False) -> None:
         self.logger.debug("Setting signal handlers")
-        set_limit_memory_hard()
         if os.name == "posix":
             signal.signal(signal.SIGINT, self.signal_handler)
             signal.signal(signal.SIGTERM, self.signal_handler)
@@ -874,7 +879,6 @@ class EventServer(CommonServer):
             time.sleep(beat)
 
     def start(self) -> None:
-        set_limit_memory_hard()
         if os.name == "posix":
             signal.signal(signal.SIGQUIT, dumpstacks)
             signal.signal(signal.SIGUSR1, log_ormcache_stats)
@@ -1296,7 +1300,9 @@ class PreforkServer(CommonServer):
             except SystemExit:
                 raise
             except BaseException as exc:
-                self.logger.critical("Uncaught error in main loop, exiting...", exc_info=exc)
+                self.logger.critical(
+                    "Uncaught error in main loop, exiting...", exc_info=exc
+                )
                 self.stop(False)
                 return -1
         return None
@@ -1366,8 +1372,6 @@ class Worker:
         if config["limit_memory_soft"] and memory > config["limit_memory_soft"]:
             self.logger.info("Virtual memory limit (%s) reached.", memory)
             self.alive = False  # Commit suicide after the request.
-
-        set_limit_memory_hard()
 
         # update RLIMIT_CPU so limit_time_cpu applies per unit of work
         r = resource.getrusage(resource.RUSAGE_SELF)
@@ -1553,7 +1557,9 @@ class WorkerCron(Worker):
             self.dbcursor.execute("SET idle_session_timeout = 0")
             self.dbcursor.execute("LISTEN cron_trigger")
         else:
-            self.logger.warning("PG cluster in recovery mode, cron trigger not activated")
+            self.logger.warning(
+                "PG cluster in recovery mode, cron trigger not activated"
+            )
         self.dbcursor.commit()
         # Rebuild the selector: wakeup pipe (OS signals) + postgres socket (NOTIFY).
         # Called on initial connect and on reconnect after connection loss.

--- a/tests/service/test_server.py
+++ b/tests/service/test_server.py
@@ -270,8 +270,13 @@ class TestWorkerCronConnectPostgres:
         """Helper: call ``_connect_postgres`` with mocked DB and selector."""
         conn, cursor = self._mock_db(in_recovery=in_recovery)
         with (
-            patch("odoo.service.server.db.db_connect", return_value=conn) as mock_connect,
-            patch("odoo.service.server.selectors.DefaultSelector", return_value=MagicMock()),
+            patch(
+                "odoo.service.server.db.db_connect", return_value=conn
+            ) as mock_connect,
+            patch(
+                "odoo.service.server.selectors.DefaultSelector",
+                return_value=MagicMock(),
+            ),
         ):
             worker_cron._connect_postgres()
         return conn, cursor, mock_connect
@@ -390,7 +395,9 @@ class TestWorkerCronProcessWorkScheduling:
     def mock_ir_cron(self):
         """Stub the deferred ``IrCron`` import inside ``process_work()``."""
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"odoo.addons.base.models.ir_cron": mock_module}):
+        with patch.dict(
+            "sys.modules", {"odoo.addons.base.models.ir_cron": mock_module}
+        ):
             yield mock_module.IrCron
 
     def test_no_databases_returns_immediately(self, worker_cron):
@@ -404,7 +411,10 @@ class TestWorkerCronProcessWorkScheduling:
         """First call with an empty queue must enqueue all databases and process one."""
         worker_cron.dbcursor._cnx.notifies.return_value = iter([])
         with (
-            patch("odoo.service.server.cron_database_list", return_value=["db1", "db2", "db3"]),
+            patch(
+                "odoo.service.server.cron_database_list",
+                return_value=["db1", "db2", "db3"],
+            ),
             patch("odoo.service.server.db"),
         ):
             worker_cron.process_work()
@@ -445,7 +455,9 @@ class TestWorkerCronProcessWorkScheduling:
         ):
             worker_cron.process_work()
 
-        all_dbs = list(worker_cron.db_queue) + [mock_ir_cron._process_jobs.call_args[0][0]]
+        all_dbs = list(worker_cron.db_queue) + [
+            mock_ir_cron._process_jobs.call_args[0][0]
+        ]
         assert "unknown_db" not in all_dbs
 
     def test_existing_queue_skips_notification_polling(self, worker_cron, mock_ir_cron):
@@ -669,7 +681,9 @@ class TestCronDatabaseList:
     def test_falls_back_to_list_dbs_when_empty(self, srv):
         with (
             patch("odoo.service.server.config", {"db_name": None}),
-            patch("odoo.service.server.list_dbs", return_value=["db1", "db2"]) as mock_list,
+            patch(
+                "odoo.service.server.list_dbs", return_value=["db1", "db2"]
+            ) as mock_list,
         ):
             result = srv.cron_database_list()
         mock_list.assert_called_once_with(True)
@@ -813,7 +827,9 @@ class TestCommonRequestHandlerLogError:
     def test_other_error_calls_super(self, srv, log_handler):
         with (
             patch("odoo.service.server._logger"),
-            patch.object(werkzeug.serving.WSGIRequestHandler, "log_error") as mock_super,
+            patch.object(
+                werkzeug.serving.WSGIRequestHandler, "log_error"
+            ) as mock_super,
         ):
             log_handler.log_error("Some other error: %s", "detail")
         mock_super.assert_called_once()
@@ -891,14 +907,18 @@ class TestRequestHandlerWebSocket:
 
     def test_websocket_connection_close_is_suppressed(self, request_handler):
         request_handler.headers.get.return_value = "websocket"
-        with patch.object(http.server.BaseHTTPRequestHandler, "send_header") as mock_send:
+        with patch.object(
+            http.server.BaseHTTPRequestHandler, "send_header"
+        ) as mock_send:
             request_handler.send_header("Connection", "close")
         mock_send.assert_not_called()
         assert request_handler.close_connection is True
 
     def test_non_websocket_connection_close_forwarded(self, request_handler):
         request_handler.headers.get.return_value = None
-        with patch.object(http.server.BaseHTTPRequestHandler, "send_header") as mock_send:
+        with patch.object(
+            http.server.BaseHTTPRequestHandler, "send_header"
+        ) as mock_send:
             request_handler.send_header("Connection", "close")
         mock_send.assert_called_once_with("Connection", "close")
         assert request_handler.close_connection is False
@@ -939,19 +959,25 @@ class TestThreadedWSGIServerSemaphore:
 
     def test_semaphore_full_skips_processing(self, threaded_server):
         threaded_server.http_threads_sem.acquire.return_value = False
-        with patch.object(werkzeug.serving.ThreadedWSGIServer, "_handle_request_noblock") as mock_super:
+        with patch.object(
+            werkzeug.serving.ThreadedWSGIServer, "_handle_request_noblock"
+        ) as mock_super:
             threaded_server._handle_request_noblock()
         mock_super.assert_not_called()
 
     def test_semaphore_acquired_calls_super(self, threaded_server):
         threaded_server.http_threads_sem.acquire.return_value = True
-        with patch.object(werkzeug.serving.ThreadedWSGIServer, "_handle_request_noblock") as mock_super:
+        with patch.object(
+            werkzeug.serving.ThreadedWSGIServer, "_handle_request_noblock"
+        ) as mock_super:
             threaded_server._handle_request_noblock()
         mock_super.assert_called_once()
 
     def test_no_semaphore_calls_super_directly(self, threaded_server):
         threaded_server.max_http_threads = None
-        with patch.object(werkzeug.serving.ThreadedWSGIServer, "_handle_request_noblock") as mock_super:
+        with patch.object(
+            werkzeug.serving.ThreadedWSGIServer, "_handle_request_noblock"
+        ) as mock_super:
             threaded_server._handle_request_noblock()
         mock_super.assert_called_once()
 
@@ -1014,14 +1040,18 @@ class TestServiceDb:
     def test_check_super_correct_password_returns_true(self, db_mod):
         import odoo.tools  # noqa: PLC0415
 
-        with patch.object(odoo.tools.config, "verify_admin_password", return_value=True):
+        with patch.object(
+            odoo.tools.config, "verify_admin_password", return_value=True
+        ):
             assert db_mod.check_super("correct") is True
 
     def test_check_super_wrong_password_raises(self, db_mod):
         import odoo.tools  # noqa: PLC0415
         from odoo.exceptions import AccessDenied  # noqa: PLC0415
 
-        with patch.object(odoo.tools.config, "verify_admin_password", return_value=False):
+        with patch.object(
+            odoo.tools.config, "verify_admin_password", return_value=False
+        ):
             with pytest.raises(AccessDenied):
                 db_mod.check_super("wrong")
 
@@ -1062,68 +1092,32 @@ class TestServiceDb:
 
 
 class TestSetLimitMemoryHard:
-    """``set_limit_memory_hard()``: applies RLIMIT_AS on Linux only."""
+    """``set_limit_memory_hard()`` is a deprecated no-op (task t22165).
 
-    def test_non_linux_is_noop(self, srv):
-        mock_resource = MagicMock()
-        with (
-            patch("odoo.service.server.platform") as mock_platform,
-            patch("odoo.service.server.resource", mock_resource),
-        ):
-            mock_platform.system.return_value = "Darwin"
-            srv.set_limit_memory_hard()
-        mock_resource.setrlimit.assert_not_called()
+    ``RLIMIT_AS`` is no longer applied to workers because modern Python (3.13+)
+    and gevent reserve large virtual address ranges that never become resident,
+    which made the kernel deny ``pthread_create`` on healthy workers. The hard
+    memory cap is now enforced externally via cgroups on the systemd unit.
+    """
 
-    def test_linux_no_limit_is_noop(self, srv):
+    def test_is_noop(self, srv):
+        """Calling the function must not touch the kernel rlimit on any platform."""
         mock_resource = MagicMock()
         mock_resource.getrlimit.return_value = (0, 9999)
         mock_resource.RLIMIT_AS = 9
         with (
-            patch("odoo.service.server.platform") as mock_platform,
-            patch("odoo.service.server.resource", mock_resource),
-            patch("odoo.service.server.config", {"limit_memory_hard": 0, "limit_memory_hard_gevent": 0}),
-            patch("odoo.service.server.odoo") as mock_odoo,
-        ):
-            mock_platform.system.return_value = "Linux"
-            mock_odoo.evented = False
-            srv.set_limit_memory_hard()
-        mock_resource.setrlimit.assert_not_called()
-
-    def test_linux_sets_rlimit(self, srv):
-        mock_resource = MagicMock()
-        mock_resource.getrlimit.return_value = (0, 9999)
-        mock_resource.RLIMIT_AS = 9
-        limit = 512 * 1024 * 1024
-        with (
-            patch("odoo.service.server.platform") as mock_platform,
-            patch("odoo.service.server.resource", mock_resource),
-            patch("odoo.service.server.config", {"limit_memory_hard": limit, "limit_memory_hard_gevent": 0}),
-            patch("odoo.service.server.odoo") as mock_odoo,
-        ):
-            mock_platform.system.return_value = "Linux"
-            mock_odoo.evented = False
-            srv.set_limit_memory_hard()
-        mock_resource.setrlimit.assert_called_once_with(9, (limit, 9999))
-
-    def test_linux_evented_uses_gevent_limit(self, srv):
-        """When running evented and ``limit_memory_hard_gevent`` is set, prefer it."""
-        mock_resource = MagicMock()
-        mock_resource.getrlimit.return_value = (0, 9999)
-        mock_resource.RLIMIT_AS = 9
-        gevent_limit = 256 * 1024 * 1024
-        with (
-            patch("odoo.service.server.platform") as mock_platform,
             patch("odoo.service.server.resource", mock_resource),
             patch(
                 "odoo.service.server.config",
-                {"limit_memory_hard": 512 * 1024 * 1024, "limit_memory_hard_gevent": gevent_limit},
+                {
+                    "limit_memory_hard": 512 * 1024 * 1024,
+                    "limit_memory_hard_gevent": 256 * 1024 * 1024,
+                },
             ),
-            patch("odoo.service.server.odoo") as mock_odoo,
         ):
-            mock_platform.system.return_value = "Linux"
-            mock_odoo.evented = True
             srv.set_limit_memory_hard()
-        mock_resource.setrlimit.assert_called_once_with(9, (gevent_limit, 9999))
+        mock_resource.setrlimit.assert_not_called()
+        mock_resource.getrlimit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1158,10 +1152,18 @@ class TestThreadedServerProcessLimit:
         ]
 
     def test_memory_soft_exceeded_adds_current_thread(self, tserver):
-        patches = self._base_patches(memory=2000, config_override={"limit_memory_soft": 1000})
-        with patches[0], patches[1], patches[2], patch("threading.enumerate", return_value=[]):
+        patches = self._base_patches(
+            memory=2000, config_override={"limit_memory_soft": 1000}
+        )
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patch("threading.enumerate", return_value=[]),
+        ):
             tserver.process_limit()
         import threading  # noqa: PLC0415
+
         assert threading.current_thread() in tserver.limits_reached_threads
 
     def test_thread_real_time_exceeded_adds_thread(self, tserver):
@@ -1172,7 +1174,12 @@ class TestThreadedServerProcessLimit:
         mock_thread.is_alive.return_value = True
 
         patches = self._base_patches(config_override={"limit_time_real": 60})
-        with patches[0], patches[1], patches[2], patch("threading.enumerate", return_value=[mock_thread]):
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patch("threading.enumerate", return_value=[mock_thread]),
+        ):
             tserver.process_limit()
         assert mock_thread in tserver.limits_reached_threads
 
@@ -1185,8 +1192,15 @@ class TestThreadedServerProcessLimit:
         mock_thread.start_time = time.monotonic() - 120
         mock_thread.is_alive.return_value = True
 
-        patches = self._base_patches(config_override={"limit_time_real": 3600, "limit_time_real_cron": 60})
-        with patches[0], patches[1], patches[2], patch("threading.enumerate", return_value=[mock_thread]):
+        patches = self._base_patches(
+            config_override={"limit_time_real": 3600, "limit_time_real_cron": 60}
+        )
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patch("threading.enumerate", return_value=[mock_thread]),
+        ):
             tserver.process_limit()
         assert mock_thread in tserver.limits_reached_threads
 
@@ -1196,7 +1210,12 @@ class TestThreadedServerProcessLimit:
         tserver.limits_reached_threads.add(dead)
 
         patches = self._base_patches()
-        with patches[0], patches[1], patches[2], patch("threading.enumerate", return_value=[]):
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patch("threading.enumerate", return_value=[]),
+        ):
             tserver.process_limit()
         assert dead not in tserver.limits_reached_threads
 
@@ -1209,14 +1228,24 @@ class TestThreadedServerProcessLimit:
         mock_thread.is_alive.return_value = True
 
         patches = self._base_patches(config_override={"limit_time_real": 60})
-        with patches[0], patches[1], patches[2], patch("threading.enumerate", return_value=[mock_thread]):
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patch("threading.enumerate", return_value=[mock_thread]),
+        ):
             tserver.process_limit()
         assert tserver.limit_reached_time is not None
 
         # remove the offending thread and run again — time should clear
         tserver.limits_reached_threads.clear()
         mock_thread.start_time = None  # no longer over limit
-        with patches[0], patches[1], patches[2], patch("threading.enumerate", return_value=[mock_thread]):
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patch("threading.enumerate", return_value=[mock_thread]),
+        ):
             tserver.process_limit()
         assert tserver.limit_reached_time is None
 
@@ -1229,7 +1258,12 @@ class TestThreadedServerProcessLimit:
         mock_thread.is_alive.return_value = True
 
         patches = self._base_patches(config_override={"limit_time_real": 1})
-        with patches[0], patches[1], patches[2], patch("threading.enumerate", return_value=[mock_thread]):
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patch("threading.enumerate", return_value=[mock_thread]),
+        ):
             tserver.process_limit()
         assert mock_thread not in tserver.limits_reached_threads
 
@@ -1261,9 +1295,13 @@ class TestThreadedServerProcessLimit:
             call_count += 1
             return original_monotonic()
 
-        with patches[0], patches[1], patches[2], \
-             patch("threading.enumerate", return_value=threads), \
-             patch("odoo.service.server.time") as mock_time:
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patch("threading.enumerate", return_value=threads),
+            patch("odoo.service.server.time") as mock_time,
+        ):
             mock_time.monotonic.side_effect = counting_monotonic
             tserver.process_limit()
 


### PR DESCRIPTION
# [Task ID: 22165](https://agromarin.mx/odoo/project.task/22165)

## Problem

The evented (gevent / longpolling / websocket) worker on production accumulated ~3 GB of virtual address space within **22 minutes** of startup. Python 3.14's allocator, gevent fiber pools, and native libraries (shapely/GEOS, scipy/openblas) reserve large VAS ranges that never become resident. With `RLIMIT_AS = 3 GB` enforced via `setrlimit()` on every worker, the kernel denied `pthread_create` on otherwise healthy workers.

The orderly recycle path never triggered either: `process_limit()` measures RSS, but the OS paged the worker out to swap (**60 MB RSS, 524 MB swap**), so the soft-limit check kept reading "all good". The worker ended up zombie — alive, accepting connections, rejecting every chatter request with `RuntimeError: can't start new thread`. `NRestarts=0` over four days confirms the master never noticed.

End-user symptom: chatter HTML rendered partially (avatars missing, messages not appearing) because every `/websocket` / `bus.bus` / `mail/init_messaging` request that landed on this worker failed.

## Solution

- `set_limit_memory_hard()` is now a deprecated no-op with a docstring explaining the rationale and pointing to cgroup v2 as the external backstop.
- Removed the three callers in `ThreadedServer.start()`, `EventServer.start()` and `Worker.process_work()`.
- Removed the now-unused `import odoo` (only `odoo.evented` relied on it; `import odoo.addons` lower in the file still exposes the namespace for `FSWatcherWatchdog`).
- Replaced `TestSetLimitMemoryHard`'s four scenario tests with a single test asserting the noop contract.

Memory control remains entirely in `process_limit()` via `memory_info()` (RSS). The hard cap previously enforced by the kernel via `RLIMIT_AS` should be set externally on the `odoo.service` systemd unit (`MemoryMax` + `MemorySwapMax=0`).

## Verification

- [x] `ruff check core/odoo/service/server.py` — 10 errors (same as baseline, no new ones)
- [x] `ruff check core/tests/service/test_server.py` — 16 errors (same as baseline, no new ones)
- [x] `ruff format` applied
- [x] Manual functional check: after the change, `srv.set_limit_memory_hard()` returns `None` and `resource.getrlimit(RLIMIT_AS)` remains `(-1, -1)` (unlimited) instead of the previous 3 GB cap
- [ ] Deploy to production and confirm zero `RuntimeError: can't start new thread` in `journalctl -u odoo.service` over 72h
- [ ] Apply cgroup backstop `/etc/systemd/system/odoo.service.d/memory.conf` with `MemoryMax=24G` and `MemorySwapMax=0` (infra change, not in this PR)