### PR TITLE
[FIX] mail: decrement inbox counter on optimistic mark-all-as-read

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -702,12 +702,14 @@ export class Thread extends Record {
 
     async markAllMessagesAsRead() {
         // Optimistic UI update: immediately clear needaction messages so the
-        // notification item disappears without waiting for the bus notification.
+        // notification item disappears and the systray counter decreases
+        // without waiting for the bus notification.
         const inbox = this.store.inbox;
         const messages = [...this.needactionMessages];
         for (const message of messages) {
             message.needaction = false;
             inbox.messages.delete(message);
+            inbox.counter--;
         }
         this.message_needaction_counter = 0;
         await this.store.env.services.orm.silent.call(


### PR DESCRIPTION
# [Task ID: 22212](https://agromarin.mx/odoo/project.task/22212)

## Problem

When the user clicks the read checkmark on a notification grouped by thread in the systray menu (e.g. `project.task` needactions), the message disappears from the dropdown but the **badge counter remains stale** until the page is reloaded.

Companion to commit f997dc0 — that fix addressed the same desync in the single-message `Message.setDone()` path, but the analogous bug in `Thread.markAllMessagesAsRead()` was not covered. In production, most needactions arrive grouped by thread (each `project.task` notification creates its own thread group), so the click in the systray ends up calling `markAllMessagesAsRead()` rather than `setDone()`. The earlier fix never runs and the badge stays stale.

The optimistic UI block on `Thread.markAllMessagesAsRead` already:
- removes each message from `store.inbox.messages`
- zeroes the thread's `message_needaction_counter`

But it does **not** decrement `store.inbox.counter`. The systray badge reads `store.globalCounter`, which is computed from `inbox.counter`, so the badge stays at its previous value until the bus event `mail.message/mark_as_read` propagates the new `needaction_inbox_counter` from the server — which in practice fails to update the badge whenever `inbox.counter_bus_id` is already ahead of the notification id (the same edge case as f997dc0).

## Solution

- Decrement `store.inbox.counter` once per message inside the optimistic loop in `Thread.markAllMessagesAsRead()`, mirroring the fix in `Message.setDone()` (f997dc0).
- The subsequent `mail.message/mark_as_read` bus event reassigns `inbox.counter` from the server, so any drift is self-correcting on the next interaction.

## Verification

Runtime monkey-patch test in production console with the proposed implementation:

| Click | Thread | Before | After | Δcounter | ΔglobalCounter | Δmessages |
|---|---|---|---|---|---|---|
| 1 | `project.task#20989` | counter=29, gc=30 | counter=28, gc=29 | -1 | -1 | -1 |
| 2 | `project.task#20597` | counter=28, gc=29 | counter=27, gc=28 | -1 | -1 | -1 |
| 3 | `project.task#20592` | counter=27, gc=28 | counter=26, gc=27 | -1 | -1 | -1 |
| 4 | `project.task#20485` | counter=26, gc=27 | counter=25, gc=26 | -1 | -1 | -1 |

In every case the badge dropped in real time, confirming the fix.

The `+1` offset between `inbox.counter` and `globalCounter` is the unrelated `channelsContribution` from `discuss/core/web/store_service_patch.js` and is out of scope here.