### PR TITLE
[FIX] api_doc, orm: harden /doc against stale fields, mixins, and PEP 649

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -138,7 +138,12 @@ class DocController(http.Controller):
                     field.name: {'string': field.field_description}
                     for field in ir_model.field_id
                     # sorted(ir_model.field_id, key=partial(sort_key_field, modules, Model))
-                    if Model._has_field_access(Model._fields[field.name], 'read')
+                    # Skip stale ir.model.fields rows whose Python field was
+                    # removed without cleaning up the metadata (e.g. a refactor
+                    # without a migration script). Crashing /doc on the first
+                    # orphan would hide the rest of the registry.
+                    if (_python_field := Model._fields.get(field.name)) is not None
+                    and Model._has_field_access(_python_field, 'read')
                 },
                 'methods': [
                     method_name
@@ -285,10 +290,32 @@ class DocController(http.Controller):
         )
         introducing_method = getattr(introducing_class, method_name)
 
-        signature = parse_signature(introducing_method)
-        return signature.as_dict() | {
-            'model': introducing_class._name or 'core',
-            'module': introducing_class._module or 'core',
+        # ``inspect.signature`` evaluates PEP 649 deferred annotations and may
+        # raise on methods whose type aliases are imported under TYPE_CHECKING
+        # (e.g. ValuesType in some BaseModel mixins). One broken method must
+        # not kill the documentation of the entire model — log and stub.
+        try:
+            signature = parse_signature(introducing_method)
+            signature_dict = signature.as_dict()
+        except Exception as exc:
+            logger.warning(
+                "api_doc: could not parse signature of %s.%s (%s): %s",
+                model_name, method_name, type(exc).__name__, exc,
+            )
+            signature_dict = {
+                'signature': '(...)',
+                'parameters': {},
+                'doc': (
+                    f"Signature could not be introspected "
+                    f"({type(exc).__name__}: {exc})."
+                ),
+            }
+        return signature_dict | {
+            # Pure-Python mixins (e.g. LifecycleMixin) sit in the MRO but
+            # have no ``_name`` / ``_module`` because they are not real Odoo
+            # models. Fall back to 'core' so the doc endpoint stays alive.
+            'model': getattr(introducing_class, '_name', None) or 'core',
+            'module': getattr(introducing_class, '_module', None) or 'core',
         }
 
 

--- a/addons/api_doc/static/src/start_doc_client.js
+++ b/addons/api_doc/static/src/start_doc_client.js
@@ -5,6 +5,16 @@ import { DocClient } from "@api_doc/doc_client";
 
 export async function startDocClient() {
     await whenReady();
+    // The XML templates for this bundle are delivered via a separate
+    // <script type="module"> that runs AFTER this one in document order.
+    // whenReady() resolves on readyState="interactive" (before DOMContentLoaded),
+    // so the templates module may still be pending. Wait for the load event
+    // (fires after readyState="complete") to guarantee registration is done.
+    if (document.readyState !== "complete") {
+        await new Promise((resolve) => {
+            window.addEventListener("load", resolve, { once: true });
+        });
+    }
     const app = new App(DocClient, {
         getTemplate,
     });

--- a/odoo/orm/models/mixins/copy.py
+++ b/odoo/orm/models/mixins/copy.py
@@ -9,12 +9,11 @@ import typing
 from collections import defaultdict
 from typing import Self
 
+from ..._typing import ValuesType  # noqa: TC003 — runtime import required (PEP 649)
 from ...primitives import MAGIC_COLUMNS, Command
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection
-
-    from ..._typing import ValuesType
 
 
 class CopyMixin:

--- a/odoo/orm/models/mixins/crud.py
+++ b/odoo/orm/models/mixins/crud.py
@@ -24,6 +24,8 @@ from odoo.tools.nplusone import _n1_enabled
 from odoo.tools.orm_profiler import _orm_profiling_enabled
 from odoo.tools.translate import _
 
+from ..._typing import ValuesType  # noqa: TC003 — runtime import required (PEP 649)
+
 # Minimum batch size to use COPY protocol instead of INSERT.
 # COPY avoids SQL parsing/planning overhead and is faster for large batches,
 # but adds +1 query (SELECT nextval) for ID pre-generation.
@@ -81,7 +83,6 @@ from ...primitives import (
 )
 
 if typing.TYPE_CHECKING:
-    from ..._typing import ValuesType
     from ...fields.base import Field
 
 

--- a/odoo/orm/models/mixins/env.py
+++ b/odoo/orm/models/mixins/env.py
@@ -10,13 +10,16 @@ import warnings
 from typing import Self
 
 from ... import decorators as api
+from ..._typing import (  # noqa: TC003 — runtime import required (PEP 649)
+    IdType,
+    ValuesType,
+)
 from ...helpers import OriginIds, _origin_ids
 from ...primitives import NewId
 
 if typing.TYPE_CHECKING:
     from collections.abc import Reversible
 
-    from ..._typing import IdType, ValuesType
     from ...runtime import Environment
 
 

--- a/odoo/orm/models/mixins/io.py
+++ b/odoo/orm/models/mixins/io.py
@@ -33,6 +33,7 @@ from odoo.tools import SQL, groupby, unique
 from odoo.tools.translate import _
 
 from ... import decorators as api
+from ..._typing import ValuesType  # noqa: TC003 — runtime import required (PEP 649)
 from ...helpers import get_columns_from_sql_diagnostics, itemgetter_tuple
 from ...parsing import fix_import_export_id_paths
 
@@ -43,8 +44,6 @@ from typing import Self
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable, Generator, Iterator
-
-    from ..._typing import ValuesType
 
 
 class IOMixin:

--- a/odoo/orm/models/mixins/read.py
+++ b/odoo/orm/models/mixins/read.py
@@ -33,12 +33,12 @@ except ImportError:
 from odoo.tools.orm_profiler import _orm_profiling_enabled
 
 from ... import decorators as api
+from ..._typing import ValuesType  # noqa: TC003 — runtime import required (PEP 649)
 from ...primitives import LOG_ACCESS_COLUMNS
 
 if typing.TYPE_CHECKING:
     from collections.abc import Collection, Sequence
 
-    from ..._typing import ValuesType
     from ...fields.base import Field
     from ...tools import Query
 


### PR DESCRIPTION
# [Task ID: 22247](https://agromarin.mx/odoo/project.task/22247)

## Problem

`/doc` (the api_doc client) was completely broken after the ESM-native migration and the BaseModel mixin refactor. Four independent issues stacked; fixing one revealed the next.

1. **OWL race** — `start_doc_client.js` called `app.mount()` before the separate `<script type="module">` carrying the templates had executed → `OwlError: Missing template "api_doc.DocClient"`. `whenReady()` resolves on `readyState="interactive"`, *before* the second module script in document order runs, so the templates were not yet registered when `app.mount()` looked them up.
2. **Stale `ir.model.fields`** — `_doc_index` crashed with `KeyError: 'use_workflow_dag'`. The field was removed from `base.automation` in commit `537a4d22920f` (workflow DAG refactor) without a migration script, so both the `ir_model_fields` row (id 7610) and the DB column survived.
3. **Mixins without `_name`/`_module`** — `_doc_method` walked the MRO assuming every ancestor was a real Odoo model and crashed on `LifecycleMixin` (and any pure-Python BaseModel mixin).
4. **PEP 649 annotations** — `inspect.signature()` raised `NameError: name 'ValuesType' is not defined` on `BaseModel.copy`/`copy_data`/etc. Five mixins (`copy.py`, `env.py`, `read.py`, `io.py`, `crud.py`) had `ValuesType` under `TYPE_CHECKING`. Python 3.14 evaluates deferred annotations at signature introspection time, so the alias must be importable at runtime. `search.py:32` already had the canonical fix; the rest had not been updated.

## Solution

**`addons/api_doc/static/src/start_doc_client.js`**
- Wait for the `load` event before calling `app.mount()` so the separate template module has finished registering.

**`addons/api_doc/controllers/api_doc.py`**
- `_doc_index`: skip stale fields with `Model._fields.get(field.name)` — one orphan row must not kill the entire index.
- `_doc_method`: use `getattr(introducing_class, '_name'/'_module', None) or 'core'` to tolerate pure-Python mixins.
- `_doc_method`: wrap `parse_signature(...)` in `try/except`, log the failure, and return a stub signature so a single broken method does not blank the whole model.

**`odoo/orm/models/mixins/{copy,env,read,io,crud}.py`**
- Move `ValuesType` (and `IdType` where used) out of `TYPE_CHECKING` with `# noqa: TC003 — runtime import required (PEP 649)`. Same pattern as `search.py:32`.

**Database cleanup on `marin190`** (applied manually, not part of this PR):
- `DELETE FROM ir_model_fields WHERE id = 7610;`
- `ALTER TABLE base_automation DROP COLUMN use_workflow_dag;`

Other AgroMarin DBs likely carry the same orphans — they will be tolerated silently by the new defensive code in `_doc_index`, but cleaning them up with the SQL above is recommended.

## Verification

- [x] `inspect.signature(CopyMixin.copy)` returns `(self, default: ValuesType | None = None) -> Self` without raising `NameError`.
- [x] `/doc` page loads; sidebar populates with the full model list.
- [x] Selecting a model returns full method documentation, including methods whose introducing class is a pure-Python mixin.
- [ ] CI green on `19.0-marin`.

## Follow-up

- Push the mixin `noqa: TC003` change upstream — any Python 3.14 user calling `inspect.signature` on `BaseModel.copy` etc. hits the same `NameError`.
- PR-review checklist item: refactors that drop a `fields.X = ...` declaration must ship a `migrations/<version>/pre-migration.py` to clean both the column and the `ir_model_fields` row; otherwise `/doc` (and any other introspection tool) trips on the orphan.