### PR TITLE
[FIX] mail: sudo on activity create_uid/user_id in _to_store_defaults

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -660,7 +660,12 @@ class MailActivity(models.Model):
             "can_write",
             "chaining_type",
             "create_date",
-            Store.One("create_uid", Store.One("partner_id", "name")),
+            # sudo on create_uid: when the activity was created by the Public
+            # user (e.g. via an HTTP webhook with no authenticated session) and
+            # the current reader is in a company that does not share with the
+            # Public user, the res.users record rule blocks the read, surfacing
+            # an Access Error on /mail/data. See task t22267.
+            Store.One("create_uid", Store.One("partner_id", "name"), sudo=True),
             "date_deadline",
             "date_done",
             "icon",
@@ -669,7 +674,10 @@ class MailActivity(models.Model):
             "res_model",
             "state",
             "summary",
-            Store.One("user_id", Store.One("partner_id")),
+            # sudo on user_id: same reasoning as create_uid above — multi-
+            # company-restricted readers must not crash on activities
+            # assigned to a user from another company.
+            Store.One("user_id", Store.One("partner_id"), sudo=True),
             Store.Many("attachment_ids", ["name"]),
             Store.Many("mail_template_ids", ["name"]),
         ]


### PR DESCRIPTION
# [Task ID: 22267](https://agromarin.mx/odoo/project.task/22267)

## Problem

When `mail.activity._to_store_defaults` serializes its `create_uid` and
`user_id` as `Store.One("...", Store.One("partner_id"))`, the inner
field read on `res.users` is **not** sudoed. For activities whose
`create_uid` or `user_id` is restricted by `base.res_users_rule`
(typically the Public user authored via HTTP webhooks without an
authenticated session, or users from other companies in multi-company
setups), the record rule blocks the read and `/mail/data` crashes with
`AccessError`.

This affects any chatter that loads activities where any user reference
is rule-restricted for the current reader. Not specific to one module —
discovered while hunting a Telegram-bot symptom, but the fix benefits
every chatter site in the platform.

## Solution

Align `mail.activity._to_store_defaults` with the analogous pattern
already canonized in `mail.message._to_store_defaults` at
`mail_message.py:1106`, where the outer `Store.One("author_id", ...)`
already passes `sudo=True`.

```python
# Before
Store.One("create_uid", Store.One("partner_id", "name")),
Store.One("user_id", Store.One("partner_id")),

# After
Store.One("create_uid", Store.One("partner_id", "name"), sudo=True),
Store.One("user_id", Store.One("partner_id"), sudo=True),
```

### Security implication

Any user who can read the activity can now also see `partner.name` of
its creator and assignee even when those users belong to a company
they don't otherwise share. This is consistent with how
`mail.message.author_id` already behaves and is the intended UX of the
chatter (you can see who authored what in the discussion).

## Verification

- [x] Diff is exactly 2 lines, `+sudo=True` in each
- [x] Manual E2E on `marin190`: opening a `approval.request` chatter as
      a single-company user that previously crashed now loads without
      popup (with this fix + complementary agromarin-addons PR applied)
- [x] No new test added in this PR — the symptom test belongs in an
      integration suite that exercises `/mail/data` with multi-company
      fixtures, which is a separate scope. The bug was found via a
      downstream telegram_bot module bug; that module's PR includes
      regression tests that exercise the env propagation path

## Related

Complements the agromarin-addons PR
[Agro-Marin/agromarin#898](https://github.com/Agro-Marin/agromarin/pull/898)
which adds the prevention layer (controller `with_user`) and historic
data cleanup. This core PR is the actual cure of the popup for any
existing record.