### PR TITLE
[FIX] sale: report ordered-policy over-invoice as "over done"

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1466,8 +1466,14 @@ class SaleOrderLine(models.Model):
 
             elif not float_is_zero(line.qty_to_invoice, precision_digits=precision):
                 if line.qty_to_invoice < 0:
-                    # Negative qty_to_invoice means refund is needed (return scenario)
-                    line.invoice_state = "to do"
+                    # Negative qty_to_invoice: more has been invoiced than is due.
+                    # For order-based products this is a genuine over-invoice.
+                    # For delivery-based products it means a return happened and a
+                    # refund/credit note is needed → action required ("to do").
+                    if line.product_id.invoice_policy == "ordered":
+                        line.invoice_state = "over done"
+                    else:
+                        line.invoice_state = "to do"
                 elif float_is_zero(line.qty_invoiced, precision_digits=precision):
                     # Nothing invoiced yet, positive qty to invoice
                     line.invoice_state = "to do"

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -1165,6 +1165,54 @@ class TestSaleToInvoice(TestSaleCommon):
         sol_prod_deliver.env.add_to_compute(qty_invoiced_field, sol_prod_deliver)
         self.assertEqual(sol_prod_deliver.qty_invoiced, expected_qty)
 
+    def test_invoice_state_over_invoiced_ordered_policy(self):
+        """Order-policy lines over-invoiced must report "over done", not "to do".
+
+        Regression for the case where qty_invoiced > product_qty on an
+        ordered-policy line produces a negative qty_to_invoice, which used to
+        short-circuit invoice_state to "to do" before reaching the
+        over-invoiced branch.
+        """
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "partner_invoice_id": self.partner_a.id,
+                "partner_shipping_id": self.partner_a.id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "product_id": self.company_data["product_order_no"].id,
+                            "product_qty": 5,
+                            "tax_ids": False,
+                        }
+                    ),
+                ],
+            }
+        )
+        line = sale_order.line_ids
+        self.assertEqual(line.product_id.invoice_policy, "ordered")
+
+        sale_order.action_confirm()
+
+        # Fully invoice the ordered quantity.
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+        self.assertEqual(line.qty_invoiced, 5.0)
+        self.assertEqual(line.invoice_state, "done")
+
+        # Reduce the ordered quantity below what was already invoiced: the line
+        # is now over-invoiced (qty_invoiced 5 > product_qty 3), so
+        # qty_to_invoice becomes negative (-2).
+        line.write({"product_qty": 3})
+        self.env.flush_all()
+        self.env.invalidate_all()
+        self.assertEqual(line.qty_to_invoice, -2.0)
+        self.assertEqual(
+            line.invoice_state,
+            "over done",
+            'Over-invoiced ordered-policy line should be "over done"',
+        )
+
     def test_multi_company_invoice(self):
         """Checks that the company of the invoices generated in a multi company environment using the
         'sale.advance.payment.inv' wizard fit with the company of the SO and not with the current company.


### PR DESCRIPTION
# [Task ID: 22455](https://agromarin.mx/odoo/project.task/22455)

## Problem

On a confirmed sale order, an ordered-policy line that ends up over-invoiced (`qty_invoiced > product_qty`) reported `invoice_state = "to do"` instead of `"over done"`. Reproduced on `OV/26/04/2548` (line 38861: ordered 3000, invoiced 6000) and confirmed on two other production orders.

## Root cause

`_compute_invoice_state` only reaches the `"over done"` branch when `qty_to_invoice == 0`. For an over-invoiced ordered-policy line, `qty_to_invoice = product_qty - qty_invoiced` is negative, so execution enters the earlier `qty_to_invoice < 0` branch and is unconditionally set to `"to do"` — a branch intended for delivery/return refund scenarios on transferred-policy products. As a result `"over done"` is effectively unreachable for ordered-policy products.

The bug appeared when a previous refactor removed the historical `max(qty_to_consider - qty_invoiced, 0.0)` clamp in `_compute_invoice_amounts` to allow negatives for refund flows, but the matching adjustment in `_compute_invoice_state` was not made.

## Solution

- In `_compute_invoice_state`, inside the `qty_to_invoice < 0` branch, discriminate by `invoice_policy`:
  - `ordered` → `"over done"` (genuine over-invoice).
  - `transferred` → `"to do"` (refund/credit note required).
- Add a regression test (`test_invoice_state_over_invoiced_ordered_policy`) covering the ordered-policy over-invoice scenario via reducing `product_qty` below `qty_invoiced` after invoicing.

## Note on existing data

Stored values written before the fix stay stale at `"to do"` until a depends-trigger field changes. To be handled post-deployment by recomputing `invoice_state` on the affected lines (filter: `invoice_policy = ordered`, `qty_invoiced > product_qty`, `invoice_state = to do`). Lines whose `qty_to_invoice` remained clamped at 0 by an earlier formula are already correct.

## Verification

Unit test: `./core/odoo-bin -c conf/agromarin190.conf -d test_sale_inv --test-tags /sale:TestSaleToInvoice.test_invoice_state_over_invoiced_ordered_policy -i sale --stop-after-init --workers=0` → `0 failed, 0 error(s) of 1 tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)