### PR TITLE
[FIX] tests: handle exception tuple in _assertRaises

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -607,13 +607,23 @@ class BaseCase(case.TestCase):
 
     @contextmanager
     def _assertRaises(
-        self, exception: type[BaseException], *, msg: str | None = None
+        self,
+        exception: type[BaseException] | tuple[type[BaseException], ...],
+        *,
+        msg: str | None = None,
     ) -> Generator[Any]:
         """Context manager that clears the environment upon failure."""
         with ExitStack() as init:
             if self.env:
                 init.enter_context(self.env.cr.savepoint())
-                if issubclass(exception, AccessError):
+                # ``assertRaises`` accepts either a single exception class or a
+                # tuple of classes; a tuple is invalid as ``issubclass`` first
+                # argument, so handle both forms explicitly.
+                if isinstance(exception, tuple):
+                    clear_cache = any(issubclass(exc, AccessError) for exc in exception)
+                else:
+                    clear_cache = issubclass(exception, AccessError)
+                if clear_cache:
                     # The savepoint() above calls flush(), which leaves the
                     # record cache with lots of data.  This can prevent
                     # access errors to be detected. In order to avoid this


### PR DESCRIPTION
# [Task ID: 22507](https://agromarin.mx/odoo/project.task/22507)

## Problem

`BaseCase._assertRaises` only accepted a single exception class, but it wraps `unittest.assertRaises` (via `super().assertRaises`), which also accepts a **tuple** of classes. When `self.env` is set, the cache-clearing guard ran:

```python
if issubclass(exception, AccessError):
```

A tuple is invalid as `issubclass` first argument → `TypeError: issubclass() arg 1 must be a class`. Any `TransactionCase` using `assertRaises((A, B))` as a context manager crashed before the asserted code ran. Without an env present the code went straight to `super().assertRaises`, which handles tuples — masking the bug.

The type annotation `exception: type[BaseException]` also did not reflect the tuple form the wrapped API supports.

## Solution

- Branch on `isinstance(exception, tuple)`: clear the cache if **any** member is an `AccessError` subclass, otherwise keep the single-class check.
- Widen the annotation to `type[BaseException] | tuple[type[BaseException], ...]`.

Single-class callers are unchanged; tuple callers stop raising `TypeError`. Style mirrors upstream master's `_raisesContext`.

## Origin & upstream reference

Preexisting **upstream** bug, not fork-local — the `issubclass` guard dates to Odoo commit `6c3bbdbef8fa8` (2022-03-29). Odoo fixed it the same way in core, but only on `master`:

- [`88fb393877`](https://github.com/odoo/odoo/commit/88fb39387768c9e42e55855cf41f20702af0f73a) — `[FIX] core: support tuple of exceptions in assertRaises` (Xavier Morel, 2026-02-26), PR [odoo/odoo#250884](https://github.com/odoo/odoo/pull/250884).

`origin/19.0` stable still carries the bug as of 2026-05-27, so this is a forward-backport to our 19.0 fork.

## Verification

- `ruff check` clean on the changed region (`core/ruff.toml`).
- Discovered via a `TransactionCase` (`approval` module) passing `(UserError, ValidationError)` as a tuple; that pattern now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)