### PR TITLE
[IMP] web: field-scoped optimistic locking in web_save

### DIFF
--- a/addons/web/models/web_read.py
+++ b/addons/web/models/web_read.py
@@ -10,10 +10,9 @@ from typing import Any
 
 from odoo import api, models
 from odoo.api import DomainType, NewId
-from odoo.exceptions import AccessError, ConcurrencyError
+from odoo.exceptions import AccessError, UserError
 from odoo.fields import Datetime as FieldsDatetime
 from odoo.tools import OrderedSet
-
 from odoo.tools.cache_version import versioned, versioned_envelope
 
 
@@ -131,18 +130,37 @@ class Base(models.AbstractModel):
         }
 
     def web_save(
-        self, vals, specification: dict[str, dict], next_id=None, last_write_date=None
+        self,
+        vals,
+        specification: dict[str, dict],
+        next_id=None,
+        last_write_date=None,
+        known_values=None,
     ) -> list[dict]:
         """Create or write a record and return it formatted per *specification*.
 
-        When *last_write_date* is provided (ISO 8601 string), the method
-        verifies that the record has not been modified by another user since
-        the client last read it.  A ``ConcurrencyError`` is raised if the
-        server's ``write_date`` is more recent, preventing silent data loss
-        from concurrent edits.
+        Optimistic concurrency control:
+
+        * *known_values* — a ``{field: baseline_value}`` map of the fields being
+          written, as the client originally read them.  Triggers a
+          **field-scoped** check: ``UserError`` is raised only if one of *those*
+          fields was changed on the server since the client read it.  Concurrent
+          writes to *other* fields (e.g. stored-compute recomputations triggered
+          by related records) touch disjoint columns, cannot cause a lost
+          update, and are ignored.  The comparison is type-aware and fails
+          OPEN — any field that cannot be safely compared is skipped rather than
+          risk a false conflict.
+        * *last_write_date* — legacy / urgent (sendBeacon) fallback: a coarser
+          row-level ``write_date`` check.
+
+        Both prevent silent data loss from concurrent edits; the field-scoped
+        path additionally avoids false conflicts from unrelated background
+        writes.
         """
         if self:
-            if last_write_date and 'write_date' in self._fields:
+            if known_values is not None:
+                self._check_concurrent_field_changes(vals, known_values)
+            elif last_write_date and 'write_date' in self._fields:
                 # Read directly from DB to avoid ORM cache (which may be stale
                 # if another user's write happened in a different transaction).
                 self.env.cr.execute(
@@ -162,13 +180,21 @@ class Base(models.AbstractModel):
                 # with .000 milliseconds, losing the microsecond precision
                 # that PostgreSQL stores.  Without this, the server value
                 # is always ~0-1s "newer" and every save triggers a false
-                # ConcurrencyError.
+                # concurrency error.
                 if server_write_date:
                     server_write_date = server_write_date.replace(microsecond=0)
                 if client_dt:
                     client_dt = client_dt.replace(microsecond=0)
                 if server_write_date and client_dt and server_write_date > client_dt:
-                    raise ConcurrencyError(
+                    # A stale read is deterministic, not a transient DB
+                    # conflict: retrying re-runs the request with the SAME
+                    # client write_date against a server write_date that only
+                    # moves forward, so it can never succeed. Raise UserError
+                    # (which retrying() does not catch) to fail fast and tell
+                    # the user to reload — NOT ConcurrencyError, whose upstream
+                    # contract marks it retryable, so retrying() would burn its
+                    # ~5x exponential backoff (~10-30s) before failing anyway.
+                    raise UserError(
                         "This record was modified by another user.\n"
                         "Please reload and re-apply your changes."
                     )
@@ -179,6 +205,98 @@ class Base(models.AbstractModel):
         if next_id:
             record = self.browse(next_id)
         return record.with_context(bin_size=True).web_read(specification)
+
+    def _check_concurrent_field_changes(self, vals, known_values):
+        """Field-scoped optimistic lock for :meth:`web_save`.
+
+        Raise ``UserError`` if a field being written (*vals*) was changed on the
+        server since the client read it (*known_values* holds the client's
+        baseline for those fields).  Concurrent writes to *other* fields are
+        ignored — they touch disjoint columns and cannot lose the user's edit.
+        Comparison is type-aware and fails OPEN: any field that cannot be safely
+        compared is skipped, never producing a false conflict.
+        """
+        self.ensure_one()
+        # Only unambiguous primitives + many2one (compared by id). date/datetime
+        # are deliberately excluded: their client serialization (Luxon, tz/ms)
+        # vs the raw DB value risks a timezone-boundary mismatch — a *false*
+        # conflict, the very thing this check exists to avoid. Excluded types
+        # fall through unchecked (fail open).
+        SAFE_TYPES = frozenset((
+            "integer", "boolean", "char", "text", "selection",
+            "float", "monetary", "many2one",
+        ))
+        names = [
+            n for n in known_values
+            if n in vals
+            and n in self._fields
+            and self._fields[n].store
+            and self._fields[n].column_type
+            and self._fields[n].type in SAFE_TYPES
+        ]
+        if not names:
+            return
+        # Read current values straight from the DB, bypassing the ORM cache
+        # (which may be stale w.r.t. a write committed by another transaction)
+        # — same rationale as the legacy write_date check below.
+        cols = ", ".join('"%s"' % n for n in names)
+        self.env.cr.execute(
+            'SELECT %s FROM "%s" WHERE id = %%s' % (cols, self._table),
+            (self.id,),
+        )
+        row = self.env.cr.fetchone()
+        if not row:
+            return
+        conflicts = []
+        for name, server_raw in zip(names, row, strict=True):
+            try:
+                field = self._fields[name]
+                current = self._coerce_concurrency_value(field, server_raw)
+                baseline = self._coerce_concurrency_value(field, known_values[name])
+                new = self._coerce_concurrency_value(field, vals[name])
+                # Conflict only if the server moved this field away from the
+                # client's baseline AND the user's write would not land on the
+                # server's current value anyway.
+                if current not in (baseline, new):
+                    conflicts.append(field.string or name)
+            except Exception:  # noqa: S112 — fail OPEN, never a false conflict
+                continue
+        if conflicts:
+            raise UserError(self.env._(
+                "This record was modified by another user while you were "
+                "editing it.\nConflicting field(s): %s.\n"
+                "Please reload and re-apply your changes.",
+                ", ".join(conflicts),
+            ))
+
+    @staticmethod
+    def _coerce_concurrency_value(field, value):
+        """Normalise *value* to a canonical primitive for concurrency compare.
+
+        Handles the client's serialized form (m2o as ``{id, display_name}``,
+        dates as ISO strings) and the raw DB form (m2o as FK id, dates as
+        ``date`` objects) to the same primitive so equal values compare equal.
+        """
+        ftype = field.type
+        if value is None or value is False:
+            return {
+                "integer": 0, "float": 0.0, "monetary": 0.0,
+                "boolean": False, "many2one": False,
+            }.get(ftype, "")
+        if ftype == "many2one":
+            if isinstance(value, dict):
+                return value.get("id") or False
+            if isinstance(value, (list, tuple)):
+                return value[0] if value else False
+            return int(value) if isinstance(value, (int, float)) else False
+        if ftype == "integer":
+            return int(value)
+        if ftype in ("float", "monetary"):
+            return round(float(value), 6)
+        if ftype == "boolean":
+            return bool(value)
+        # char, text, selection
+        return str(value)
 
     def web_save_multi(
         self, vals_list: list[dict], specification: dict[str, dict]

--- a/addons/web/static/src/fields/field_widths.js
+++ b/addons/web/static/src/fields/field_widths.js
@@ -50,12 +50,12 @@ export const FIELD_WIDTHS = Object.freeze({
         }
         return _dateWidths.numericDatetime;
     },
-    float: 93,
-    integer: 71,
+    float: [120, 200],
+    integer: [100, 180],
     many2many: [80],
     many2one_reference: [80],
     many2one: [80],
-    monetary: 105,
+    monetary: [140, 240],
     one2many: [80],
     reference: [80],
     selection: [80],

--- a/addons/web/static/src/model/relational_model/record_save.js
+++ b/addons/web/static/src/model/relational_model/record_save.js
@@ -52,6 +52,25 @@ export async function save(record, { reload = true, onError, nextId } = {}) {
     }
     const changes = record._getChanges();
     delete changes.id; // id never changes, and should not be written
+    // Field-scoped optimistic locking: capture the originally-loaded (baseline)
+    // value of each field being written, so the server rejects only a genuine
+    // per-field conflict and ignores concurrent writes to OTHER fields (e.g.
+    // background stored-compute recomputations). Types whose value can't be
+    // compared safely (x2many, binary, html, date/datetime, ...) are omitted;
+    // the server skips any field it has no baseline for (fails open).
+    const concurrencyBaseline = {};
+    for (const fieldName of Object.keys(changes)) {
+        const fieldType = record.fields[fieldName]?.type;
+        if (
+            fieldType &&
+            ![
+                "one2many", "many2many", "binary", "html",
+                "date", "datetime", "json", "properties", "reference",
+            ].includes(fieldType)
+        ) {
+            concurrencyBaseline[fieldName] = record._values[fieldName];
+        }
+    }
     if (!creation && !Object.keys(changes).length) {
         if (nextId) {
             // No changes — caller wants to navigate to ``nextId``. Run the
@@ -78,17 +97,17 @@ export async function save(record, { reload = true, onError, nextId } = {}) {
         // payload (typically < 64k). So we try to save with sendBeacon, and if it
         // doesn't work, we will prevent the page from unloading.
         const route = `/web/dataset/call_kw/${record.resModel}/web_save`;
-        // Optimistic locking: mirror the normal-save path's last_write_date
-        // logic (below) so the server can reject concurrent edits even when the
-        // save was initiated by sendBeacon on tab close. The normal path guards
-        // on `record.resId && write_date`; here a present `write_date` already
-        // implies the record was persisted (so resId is truthy), so guarding on
-        // write_date alone is sufficient.
-        const urgentKwargs = { context: record.context, specification: {} };
-        if (record._values.write_date) {
-            const wd = record._values.write_date;
-            urgentKwargs.last_write_date = typeof wd === "string" ? wd : wd.toISO();
-        }
+        // Field-scoped optimistic locking: mirror the normal-save path so the
+        // server can reject a genuine concurrent edit even when the save was
+        // initiated by sendBeacon on tab close. This branch only runs for an
+        // existing record (resId truthy), so the baseline is meaningful; an
+        // empty baseline (e.g. only x2many changed) simply skips the check —
+        // the right call on tab close, where we must never drop the user's work.
+        const urgentKwargs = {
+            context: record.context,
+            specification: {},
+            known_values: concurrencyBaseline,
+        };
         const params = {
             model: record.resModel,
             method: "web_save",
@@ -144,11 +163,11 @@ export async function save(record, { reload = true, onError, nextId } = {}) {
         specification: fieldSpec,
         next_id: nextId,
     };
-    // Optimistic locking: send write_date so the server can detect concurrent edits
-    if (record.resId && record._values.write_date) {
-        const wd = record._values.write_date;
-        // write_date may be a Luxon DateTime or a string
-        kwargs.last_write_date = typeof wd === "string" ? wd : wd.toISO();
+    // Field-scoped optimistic locking: send the baseline values of the fields
+    // being written so the server rejects only genuine per-field conflicts and
+    // ignores concurrent writes to other fields. (Empty baseline => no check.)
+    if (record.resId) {
+        kwargs.known_values = concurrencyBaseline;
     }
     /** @type {Record<string, any>[]} */
     let records;

--- a/addons/web/static/src/public/database_manager.js
+++ b/addons/web/static/src/public/database_manager.js
@@ -45,10 +45,11 @@ document.addEventListener("DOMContentLoaded", function () {
     // db modal
     document.body.addEventListener("click", function (ev) {
         const target = /** @type {HTMLElement} */ (ev.target);
-        if (target.classList.contains("o_database_action")) {
+        const action = target.closest(".o_database_action");
+        if (action) {
             ev.preventDefault();
-            const db = target.getAttribute("data-db");
-            const bsTarget = target.getAttribute("data-bs-target");
+            const db = action.getAttribute("data-db");
+            const bsTarget = action.getAttribute("data-bs-target");
             const modal = Modal.getOrCreateInstance(document.querySelector(bsTarget));
             const inputName = modal._element.querySelector("input[name=name]");
             if (inputName) {

--- a/addons/web/tests/test_web_save.py
+++ b/addons/web/tests/test_web_save.py
@@ -1,87 +1,128 @@
-"""Tests for web_save with optimistic locking (concurrency detection)."""
+"""Tests for web_save optimistic locking (field-scoped concurrency detection).
 
-from datetime import datetime, timedelta
+The field-scoped check raises ``UserError`` only when a field the user is
+writing was changed on the server since the client read it.  Concurrent writes
+to *other* fields (e.g. stored-compute recomputations triggered by related
+records) touch disjoint columns and must NOT block the save.
+"""
 
-from odoo.exceptions import ConcurrencyError
+from datetime import timedelta
+
+from odoo.exceptions import UserError
 from odoo.tests import common
 
 
 @common.tagged("post_install", "-at_install", "web_unit", "web_save")
 class TestWebSaveOptimisticLocking(common.TransactionCase):
-    """Verify that web_save raises ConcurrencyError when the record has
-    been modified by another user since the client last read it."""
+    """Field-scoped optimistic locking in web_save."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
+        cls.c1 = cls.env["res.partner"].create({"name": "Company 1", "is_company": True})
+        cls.c2 = cls.env["res.partner"].create({"name": "Company 2", "is_company": True})
+        cls.c3 = cls.env["res.partner"].create({"name": "Company 3", "is_company": True})
+        cls.partner = cls.env["res.partner"].create({
+            "name": "Base Partner",
+            "phone": "111",
+            "function": "f0",
+            "parent_id": cls.c1.id,
+        })
+        cls.env.flush_all()  # ensure the DB holds these values for raw reads
 
-    def test_web_save_without_locking(self):
-        """web_save without last_write_date should work as before."""
-        result = self.partner.web_save(
-            {"name": "Updated"},
-            specification={"name": {}},
-        )
-        self.assertEqual(result[0]["name"], "Updated")
-
-    def test_web_save_with_matching_write_date(self):
-        """web_save with matching last_write_date should succeed."""
-        write_date = self.partner.write_date
-        result = self.partner.web_save(
-            {"name": "Updated Again"},
-            specification={"name": {}},
-            last_write_date=write_date.isoformat(),
-        )
-        self.assertEqual(result[0]["name"], "Updated Again")
-
-    def test_web_save_with_stale_write_date(self):
-        """web_save with stale last_write_date should raise ConcurrencyError."""
-        # Simulate client reading at an earlier time
-        stale_write_date = self.partner.write_date - timedelta(seconds=10)
-
-        # Modify the record (simulates another user saving)
-        self.partner.write({"name": "Changed by User A"})
-
-        # Now try to save with the stale write_date
-        with self.assertRaises(ConcurrencyError):
-            self.partner.web_save(
-                {"name": "Changed by User B"},
-                specification={"name": {}},
-                last_write_date=stale_write_date.isoformat(),
+    def _server_set(self, **col_vals):
+        """Simulate another transaction committing a change, at the DB level
+        (bypasses the ORM cache, exactly like a concurrent worker would)."""
+        for col, val in col_vals.items():
+            self.env.cr.execute(
+                'UPDATE res_partner SET "%s" = %%s WHERE id = %%s' % col,
+                (val, self.partner.id),
             )
 
-    def test_web_save_create_ignores_locking(self):
-        """web_save for creation should ignore last_write_date (no record to check)."""
-        empty_recordset = self.env["res.partner"]
-        result = empty_recordset.web_save(
-            {"name": "New Partner"},
-            specification={"name": {}},
-            last_write_date="2020-01-01T00:00:00",
+    # -- no concurrency args: behaves as an ordinary save --------------------
+    def test_no_concurrency_args(self):
+        result = self.partner.web_save({"phone": "x"}, specification={"phone": {}})
+        self.assertEqual(result[0]["phone"], "x")
+
+    def test_create_ignores_locking(self):
+        result = self.env["res.partner"].web_save(
+            {"name": "New"}, specification={"name": {}},
+            known_values={"name": "anything"},
         )
-        self.assertEqual(result[0]["name"], "New Partner")
+        self.assertEqual(result[0]["name"], "New")
 
-    def test_web_save_concurrent_edit_preserves_first_save(self):
-        """Full concurrency scenario: simulated concurrent modification.
-
-        Within a TransactionCase all writes share the same transaction
-        timestamp, so we simulate "another user" by directly advancing
-        write_date in the DB before User B's save attempt.
-        """
-        # Client snapshot — what the user's browser saw when loading the form
-        client_write_date = self.partner.write_date - timedelta(seconds=5)
-
-        # Simulate that the server record was modified since the client read it
-        # (another user saved, or a cron updated it)
-        server_future = self.partner.write_date + timedelta(seconds=1)
-        self.env.cr.execute(
-            "UPDATE res_partner SET write_date = %s WHERE id = %s",
-            (server_future, self.partner.id),
+    # -- field-scoped: the core behaviour ------------------------------------
+    def test_disjoint_change_does_not_conflict(self):
+        """A concurrent change to a DIFFERENT field must not block the save."""
+        self._server_set(function="changed-by-other")
+        self.partner.web_save(
+            {"phone": "222"}, specification={"phone": {}},
+            known_values={"phone": "111"},
         )
+        self.assertEqual(self.partner.phone, "222")
 
-        # User B tries to save with the outdated write_date — should fail
-        with self.assertRaises(ConcurrencyError):
+    def test_same_field_conflict(self):
+        """A concurrent change to the SAME field the user edits -> UserError."""
+        self._server_set(phone="999")
+        with self.assertRaises(UserError):
             self.partner.web_save(
-                {"name": "User B Edit"},
-                specification={"name": {}},
-                last_write_date=client_write_date.isoformat(),
+                {"phone": "222"}, specification={"phone": {}},
+                known_values={"phone": "111"},
+            )
+
+    def test_same_field_same_value_no_conflict(self):
+        """If the server already holds the value the user is writing, no loss."""
+        self._server_set(phone="222")
+        self.partner.web_save(
+            {"phone": "222"}, specification={"phone": {}},
+            known_values={"phone": "111"},
+        )
+        self.assertEqual(self.partner.phone, "222")
+
+    def test_many2one_conflict(self):
+        """Concurrent reassignment of a many2one the user also edits -> error."""
+        self._server_set(parent_id=self.c2.id)
+        with self.assertRaises(UserError):
+            self.partner.web_save(
+                {"parent_id": self.c3.id}, specification={"parent_id": {}},
+                known_values={"parent_id": {"id": self.c1.id, "display_name": "Company 1"}},
+            )
+
+    def test_many2one_user_change_no_conflict(self):
+        """User reassigns a many2one nobody else touched -> no conflict."""
+        self.partner.web_save(
+            {"parent_id": self.c3.id}, specification={"parent_id": {}},
+            known_values={"parent_id": {"id": self.c1.id, "display_name": "Company 1"}},
+        )
+        self.assertEqual(self.partner.parent_id, self.c3)
+
+    def test_only_written_fields_are_checked(self):
+        """A baseline for a field NOT being written is ignored (only vals count)."""
+        self._server_set(parent_id=self.c2.id)  # changed, but user isn't writing it
+        self.partner.web_save(
+            {"phone": "222"}, specification={"phone": {}},
+            known_values={
+                "phone": "111",
+                "parent_id": {"id": self.c1.id, "display_name": "Company 1"},
+            },
+        )
+        self.assertEqual(self.partner.phone, "222")
+
+    def test_empty_known_values_skips_check(self):
+        """No comparable baselines (e.g. x2many-only edit) -> never blocks."""
+        self._server_set(phone="999")
+        self.partner.web_save(
+            {"phone": "222"}, specification={"phone": {}},
+            known_values={},
+        )
+        self.assertEqual(self.partner.phone, "222")
+
+    # -- legacy row-level fallback still works -------------------------------
+    def test_legacy_last_write_date_fallback(self):
+        stale = self.partner.write_date - timedelta(seconds=10)
+        self._server_set(write_date=self.partner.write_date + timedelta(seconds=5))
+        with self.assertRaises(UserError):
+            self.partner.web_save(
+                {"phone": "222"}, specification={"phone": {}},
+                last_write_date=stale.isoformat(),
             )


### PR DESCRIPTION
# [Task ID: 22839](https://agromarin.mx/odoo/project.task/22839)

## Problem
The optimistic lock in `web_save` was row-level (`write_date` → `ConcurrencyError`): any concurrent write to the record — including background stored-compute recomputations triggered by related records — produced a false conflict and blocked the user's save, even though the columns touched were disjoint.

## Solution
- **`web_read.py`**: new optional `known_values` param (`{field: baseline}` as the client read them). `_check_concurrent_field_changes` reads current values straight from the DB (bypassing stale ORM cache) and raises `UserError` only when a field the user is writing changed on the server. Type-aware, **fails open** (`date`/`datetime` and other non-comparable types skipped — never a false conflict). Helper `_coerce_concurrency_value` normalizes client (m2o `{id, display_name}`, ISO dates) vs raw DB form.
- Legacy `last_write_date` fallback (sendBeacon/urgent) now raises `UserError` instead of `ConcurrencyError`: a stale read is deterministic, not a transient DB conflict, so `retrying()` would only burn its ~10–30s backoff before failing anyway.
- **`record_save.js`**: captures the per-field baseline, omits non-comparable types (x2many, binary, html, date/datetime, json, properties, reference), sends `known_values` in both the normal save and the urgent sendBeacon (tab-close) path.
- **`field_widths.js`**: numeric column widths become `[min, max]` ranges — float `[120,200]`, integer `[100,180]`, monetary `[140,240]`.
- **`database_manager.js`**: DB action click uses `closest(".o_database_action")` so clicks on the button's child elements work.
- **`test_web_save.py`**: rewritten for the field-scoped model (disjoint-no-conflict, same-field-conflict, same-value-no-conflict, many2one, only-written-fields-checked, empty-baseline-skips, legacy fallback).

## Risk / notes
- `web_save` contract change is backward compatible (new optional param).
- Exception type changes `ConcurrencyError` → `UserError`; review anything depending on the type.

## Verification
- `ruff check` clean on changed Python.
- Run `--test-tags '/web,web_save'` and confirm all field-scoped cases pass.
