### PR TITLE
[FIX] html_editor: file upload broken by ESM rpc() whitelist

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
@@ -89,6 +89,9 @@ export const uploadService = {
                         id,
                         name: file.name,
                         size: fileSize,
+                        // fetch-based rpc() exposes no upload progress, so this
+                        // stays at 0 until the request resolves (spinner shown).
+                        progress: 0,
                     });
                 }
 
@@ -108,15 +111,11 @@ export const uploadService = {
                         continue;
                     }
                     try {
-                        const xhr = new XMLHttpRequest();
-                        xhr.upload.addEventListener("progress", (ev) => {
-                            const rpcComplete = (ev.loaded / ev.total) * 100;
-                            file.progress = rpcComplete;
-                        });
-                        xhr.upload.addEventListener("load", function () {
-                            // Don't show yet success as backend code only starts now
-                            file.progress = 100;
-                        });
+                        // rpc() is fetch-based since the native-ESM migration
+                        // and rejects unknown settings (the legacy { xhr }
+                        // progress handle now throws "Invalid RPC setting(s)").
+                        // Granular upload progress is therefore not available;
+                        // the toast falls back to the indeterminate spinner.
                         const attachment = await rpc(
                             "/html_editor/attachment/add_data",
                             {
@@ -127,8 +126,7 @@ export const uploadService = {
                                 is_image: !!isImage,
                                 width: 0,
                                 quality: 0,
-                            },
-                            { xhr }
+                            }
                         );
                         if (attachment.error) {
                             file.hasError = true;
@@ -159,8 +157,7 @@ export const uploadService = {
                                         is_image: true,
                                         width: 0,
                                         quality: 0,
-                                    },
-                                    { xhr }
+                                    }
                                 );
                             }
                             file.uploaded = true;


### PR DESCRIPTION
# [Task ID: 22842](https://agromarin.mx/odoo/project.task/22842)

## Problem

File uploads inside any HTML field (the **Description** tab on `approval.request` and every other model with an html field) fail with a generic *"File could not be saved"* toast. Nothing appears in the browser console and **no request reaches the server**.

## Root cause

The native-ESM migration ([Task ID 22655](https://agromarin.mx/odoo/project.task/22655), commit `34d4d0640a60`) rewrote `core/addons/web/static/src/core/network/rpc.js`: `rpc()` is now fetch-based and validates its settings against a strict whitelist:

```js
const RPC_SETTINGS = new Set(["cache", "silent", "headers", "timeout", "retry", "dedup"]);
```

`xhr` is absent. The media upload service (`html_editor/.../upload_progress_toast/upload_service.js`) still passed `{ xhr }` to wire upload progress, so `validateRPCSettings()` throws `Invalid RPC setting(s): xhr` **synchronously, before any request is sent**. The throw is swallowed by the upload service try/catch, leaving only the generic toast.

Scope: affects **all** html-field file/image uploads. Server-side path (`ir.attachment.create` + `_get_media_info`) verified clean.

## Solution

- Remove the `{ xhr }` argument from both `/html_editor/attachment/add_data` `rpc()` calls.
- Drop the now-unused `XMLHttpRequest` progress wiring.
- Initialize `file.progress` to `0` so the toast renders the spinner cleanly.

Granular upload progress is no longer available with fetch-based `rpc()`; a follow-up can restore it via a fetch `ReadableStream`.

## Verification

- Reproduced locally on `marin190` (foreground + `--dev=assets`): before the fix, **no** `POST /html_editor/attachment/add_data` in the server log; after the fix the request returns **200** and the file is inserted into the editor.
- Server-side attachment create + `_get_media_info` confirmed working for admin and non-admin users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)