### PR TITLE
[FIX] web: exclude jsonb fields from web_save optimistic locking

### DIFF
--- a/addons/web/models/web_read.py
+++ b/addons/web/models/web_read.py
@@ -220,8 +220,11 @@ class Base(models.AbstractModel):
         # Only unambiguous primitives + many2one (compared by id). date/datetime
         # are deliberately excluded: their client serialization (Luxon, tz/ms)
         # vs the raw DB value risks a timezone-boundary mismatch — a *false*
-        # conflict, the very thing this check exists to avoid. Excluded types
-        # fall through unchecked (fail open).
+        # conflict, the very thing this check exists to avoid. jsonb-backed
+        # columns (translated / company-dependent fields) are excluded for the
+        # same reason: the raw DB value is a per-lang / per-company dict, not
+        # the scalar the client read. Excluded types fall through unchecked
+        # (fail open).
         SAFE_TYPES = frozenset((
             "integer", "boolean", "char", "text", "selection",
             "float", "monetary", "many2one",
@@ -232,6 +235,7 @@ class Base(models.AbstractModel):
             and n in self._fields
             and self._fields[n].store
             and self._fields[n].column_type
+            and self._fields[n].column_type[0] != "jsonb"
             and self._fields[n].type in SAFE_TYPES
         ]
         if not names:

--- a/addons/web/static/src/model/relational_model/record_save.js
+++ b/addons/web/static/src/model/relational_model/record_save.js
@@ -60,13 +60,18 @@ export async function save(record, { reload = true, onError, nextId } = {}) {
     // the server skips any field it has no baseline for (fails open).
     const concurrencyBaseline = {};
     for (const fieldName of Object.keys(changes)) {
-        const fieldType = record.fields[fieldName]?.type;
+        const field = record.fields[fieldName];
         if (
-            fieldType &&
+            field?.type &&
             ![
                 "one2many", "many2many", "binary", "html",
                 "date", "datetime", "json", "properties", "reference",
-            ].includes(fieldType)
+            ].includes(field.type) &&
+            // jsonb-backed columns: the server-side raw read returns a
+            // per-lang / per-company dict, never comparable to the scalar
+            // the client read — the server skips them, so don't send them.
+            !field.translate &&
+            !field.company_dependent
         ) {
             concurrencyBaseline[fieldName] = record._values[fieldName];
         }

--- a/addons/web/tests/test_web_save.py
+++ b/addons/web/tests/test_web_save.py
@@ -117,6 +117,35 @@ class TestWebSaveOptimisticLocking(common.TransactionCase):
         )
         self.assertEqual(self.partner.phone, "222")
 
+    # -- jsonb-backed columns (translated / company-dependent) fail open -----
+    def test_translated_field_no_false_conflict(self):
+        """Editing a translated field must not self-conflict: the raw DB value
+        is a per-lang jsonb dict, never equal to the scalar the client read."""
+        category = self.env["res.partner.category"].create({"name": "Original"})
+        self.env.flush_all()
+        self.assertTrue(category._fields["name"].translate)  # guard the premise
+        category.web_save(
+            {"name": "Renamed"}, specification={"name": {}},
+            known_values={"name": "Original"},
+        )
+        self.assertEqual(category.name, "Renamed")
+
+    def test_translated_field_fails_open(self):
+        """A genuine concurrent change to a translated field is NOT detected
+        (fail open): the jsonb dict cannot be safely compared to the client's
+        scalar baseline, so the field is skipped rather than false-conflict."""
+        category = self.env["res.partner.category"].create({"name": "Original"})
+        self.env.flush_all()
+        self.env.cr.execute(
+            "UPDATE res_partner_category SET name = %s WHERE id = %s",
+            ('{"en_US": "Changed Elsewhere"}', category.id),
+        )
+        category.web_save(
+            {"name": "Renamed"}, specification={"name": {}},
+            known_values={"name": "Original"},
+        )
+        self.assertEqual(category.name, "Renamed")
+
     # -- legacy row-level fallback still works -------------------------------
     def test_legacy_last_write_date_fallback(self):
         stale = self.partner.write_date - timedelta(seconds=10)


### PR DESCRIPTION
# [Task ID: 22868](https://agromarin.mx/odoo/project.task/22868)

Follow-up to the field-scoped optimistic locking feature ([Task ID: 22839](https://agromarin.mx/odoo/project.task/22839), commit `4ecbac1e7cba`).

## Problem

The concurrency baseline in `web_save` included fields backed by `jsonb` columns (translated fields and `company_dependent` fields). For these the raw DB value is a per-lang / per-company dict, never equal to the scalar the client read. Editing such a field (e.g. renaming a translated `name`) raised a **false conflict** `UserError` even with no concurrent change.

## Solution

- **`web_read.py`** (`_check_concurrent_field_changes`): skip fields whose `column_type[0] == "jsonb"`; they fall through unchecked (fail open).
- **`record_save.js`** (`save`): client no longer sends a baseline for `translate` / `company_dependent` fields — the server skips them anyway.
- **`test_web_save.py`**: two new tests — no self-conflict editing a translated field, and a genuine concurrent change to a translated field fails open.

## Verification

```bash
./addons/core/odoo-bin -c ./conf/agromarin190.conf -d test_db \
    --test-tags '/web' -u web --stop-after-init --workers=0
```

Confirm `test_translated_field_no_false_conflict` and `test_translated_field_fails_open` pass.