### PR TITLE
[FIX] sales_team: leader access + archive-sync for crm.team

### DIFF
--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -230,6 +230,18 @@ class CrmTeam(models.Model):
             self._add_members_to_favorites()
         return res
 
+    def action_archive(self):
+        """Archive the teams and cascade the archive to their memberships.
+
+        Team-side mirror of :meth:`res.users.action_archive`: a membership
+        pointing to an archived team is dangling residue, so it is archived
+        too. This frees the members' ``crm_team_ids`` / ``sale_team_id`` to
+        recompute against live teams only. Restoring the team does not
+        resurrect the memberships, exactly like the user-side counterpart.
+        """
+        self.crm_team_member_ids.action_archive()
+        return super().action_archive()
+
     @api.ondelete(at_uninstall=False)
     def _unlink_except_default(self):
         default_teams = [

--- a/addons/sales_team/security/sales_team_security.xml
+++ b/addons/sales_team/security/sales_team_security.xml
@@ -54,17 +54,19 @@
 
     <data noupdate="1">
 
+        <!-- A user accesses the teams they belong to (member) or lead (responsible),
+             matching the member-OR-responsible heuristic of crm.team._get_default_team_id. -->
         <record id="crm_rule_personal_salesteam" model="ir.rule">
             <field name="name">Personal Salesteam</field>
             <field name="model_id" ref="model_crm_team" />
-            <field name="domain_force">[('id', 'in', user.crm_team_ids.ids)]</field>
+            <field name="domain_force">['|', ('user_id', '=', user.id), ('id', 'in', user.crm_team_ids.ids)]</field>
             <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman'))]" />
         </record>
 
         <record id="crm_rule_team_salesteam" model="ir.rule">
             <field name="name">Team Salesteam</field>
             <field name="model_id" ref="model_crm_team" />
-            <field name="domain_force">[('id', 'in', user.crm_team_ids.ids)]</field>
+            <field name="domain_force">['|', ('user_id', '=', user.id), ('id', 'in', user.crm_team_ids.ids)]</field>
             <field name="groups" eval="[(4, ref('sales_team.group_sale_salesman_team'))]" />
         </record>
 

--- a/addons/sales_team/tests/test_sales_team_membership.py
+++ b/addons/sales_team/tests/test_sales_team_membership.py
@@ -25,6 +25,40 @@ class TestMembership(TestSalesCommon):
         self.user_sales_leads.action_archive()
         self.assertFalse(self.sales_team_1_m1.active)
 
+    def test_archive_team_archives_team_member(self):
+        """Archiving a team archives its memberships (team-side mirror of user archive)."""
+        self.assertTrue(self.sales_team_1_m1.active)
+        self.assertTrue(self.sales_team_1_m2.active)
+        self.sales_team_1.action_archive()
+        self.assertFalse(self.sales_team_1_m1.active)
+        self.assertFalse(self.sales_team_1_m2.active)
+        # Asymmetric on purpose: restoring the team does not resurrect memberships,
+        # exactly like res.users.action_archive on the user side.
+        self.sales_team_1.action_unarchive()
+        self.assertFalse(self.sales_team_1_m1.active)
+        self.assertFalse(self.sales_team_1_m2.active)
+
+    def test_leader_can_read_led_team(self):
+        """A plain salesman reads a team they lead even without a membership."""
+        # crm_rule_personal_salesteam is a noupdate record, so `-u` does not refresh
+        # its domain on existing databases; the deploy-time migration replicates this
+        # write. Setting it here keeps the test deterministic on any database state.
+        leader_domain = "['|', ('user_id', '=', user.id), ('id', 'in', user.crm_team_ids.ids)]"
+        self.env.ref('sales_team.crm_rule_personal_salesteam').domain_force = leader_domain
+        salesman = self.user_sales_salesman  # group_sale_salesman -> rule 705 only
+        led_team = self.env['crm.team'].create({
+            'name': 'Led Not Member', 'company_id': False, 'user_id': salesman.id,
+        })
+        foreign_team = self.env['crm.team'].create({
+            'name': 'Foreign Team', 'company_id': False, 'user_id': self.user_sales_manager.id,
+        })
+        self.assertNotIn(salesman, led_team.member_ids, "leader must not be auto-added as member")
+        # leader-aware rule: the salesman reads the team they lead...
+        self.assertEqual(led_team.with_user(salesman).read(['name'])[0]['name'], 'Led Not Member')
+        # ...but still cannot read a team they neither lead nor belong to.
+        with self.assertRaises(exceptions.AccessError):
+            foreign_team.with_user(salesman).read(['name'])
+
     @users('user_sales_manager')
     def test_fields(self):
         self.assertTrue(self.sales_team_1.with_user(self.env.user).is_membership_multi)


### PR DESCRIPTION
# [Task ID: 22869](https://agromarin.mx/odoo/project.task/22869)

## Problem

A team leader (`crm.team.user_id`) had no access to the team they lead unless
they were also a member. Rules `crm_rule_personal_salesteam` /
`crm_rule_team_salesteam` filter `crm.team` only by membership
(`user.crm_team_ids`), while the team default heuristic
`_get_default_team_id` treats "my teams" as member **OR** responsible. A leader
of a member-less team hits `AccessError` when assigning it on a quotation.

Symmetrically, archiving a team left its memberships active and dangling:
`res.users.action_archive` cascades to memberships, but `crm.team` had no
counterpart — so after a team restructure a leader's `sale_team_id` kept
pointing at an archived team.

## Solution

- `crm.team.action_archive` now cascades the archive to `crm_team_member_ids`
  (mirror of `res.users.action_archive`; restoring the team does **not**
  resurrect the memberships — same asymmetry as the user side).
- `crm_rule_personal_salesteam` / `crm_rule_team_salesteam` domain extended to
  `['|', ('user_id', '=', user.id), ('id', 'in', user.crm_team_ids.ids)]`,
  aligning record-level security with the member-OR-responsible heuristic.
- Tests: archive-sync on the team side; a restricted salesman leader can read
  the team they lead without a membership, a foreigner still cannot.

> **Note (existing DBs):** the two rules are `noupdate="1"`, so `-u` does not
> refresh their domain. Existing databases get the new domain via a one-time
> data migration applied at deploy (out of this PR's scope).

## Verification

- `ruff check`: no new findings on the diff (module carries pre-existing
  upstream lint debt; intentionally **not** reformatted, to keep the file
  mergeable against upstream Odoo).
- `--test-tags '/sales_team' -u sales_team`: **0 failed, 0 error of 20 tests**
  (was 18). New tests bite: disabling the archive cascade → 1 failed.
- Validated on a fresh production clone (`marin190_t22869`): restricted leader
  reads a team they lead without membership (with negative control); archiving
  a team archives its memberships; UI-confirmed (a restricted leader sees only
  their teams and assigns their POS team via leadership).
