### PR TITLE
[FIX] base: serve web_studio bundles as low-overlap ESM (light+dark)

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -310,6 +310,17 @@ This module provides the core of the Odoo Web Client.
             ),
             "web/static/src/**/*.dark.scss",
         ],
+        "web.assets_backend_dark": [
+            (
+                "include",
+                "web._assets_helpers",
+            ),
+            (
+                "include",
+                "web._assets_backend_helpers",
+            ),
+            "web/static/src/**/*.dark.scss",
+        ],
         "web._assets_core": [
             "web/static/lib/luxon/luxon.js",
             "web/static/src/session.js",

--- a/addons/web_hierarchy/__manifest__.py
+++ b/addons/web_hierarchy/__manifest__.py
@@ -19,6 +19,11 @@ an organization such as an Organization Chart for employees for instance.
             ('remove', 'web_hierarchy/static/src/hierarchy.variables.dark.scss'),
         ],
         "web.assets_backend_dark": [
+            # Light anchor must be present in the dark bundle for the swap
+            # below: web.assets_backend_dark no longer includes
+            # web.assets_backend (Studio low-overlap reshape, t22867), so
+            # the module self-provides its variables file as the anchor.
+            'web_hierarchy/static/src/hierarchy.variables.scss',
             ('before', 'web_hierarchy/static/src/hierarchy.variables.scss', 'web_hierarchy/static/src/hierarchy.variables.dark.scss'),
         ],
         'web.assets_unit_tests': [

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -228,13 +228,18 @@ _ESM_EXPORT_DEFAULT_RE_SRC = (
 )
 _ESM_EXPORT_DEFAULT_RE = re.compile(_ESM_EXPORT_DEFAULT_RE_SRC)
 
-# Import-discovery regex for ``_discover_bridge_specifiers``: the three import
-# shapes that pull a specifier from an ``@addon`` module, unified into ONE
-# alternation so each source file is scanned a single time (one ``finditer``)
-# instead of three.  Per-branch whitespace is preserved exactly — a default
-# import requires ``\s+`` around the binding while named/star allow ``\s*`` —
-# and the import kind is read from whichever named group matched.  Module-level
-# so it compiles once instead of on every bundle build.
+# Import-discovery regex for ``_discover_bridge_specifiers``: every import shape
+# that pulls a specifier from an ``@addon`` module, unified into ONE alternation
+# so each source file is scanned a single time (one ``finditer``).  Branches
+# 1-3 carry a binding and a ``from`` (named/star/default — the kind is read from
+# whichever named group matched); per-branch whitespace is preserved exactly, a
+# default import requires ``\s+`` around the binding while named/star allow
+# ``\s*``.  Branch 4 is the bindingless side-effect form ``import "@addon/…";``
+# (no ``from``), whose specifier lands in the ``side`` group: it matters because
+# a low-overlap dynamic child that only side-effect-imports a parent specifier
+# (t22867: Studio -> ``@mail/chatter/web/chatter_patch`` + two ``@web_enterprise``
+# patches) would otherwise never bridge it and fail at runtime with "Failed to
+# resolve module specifier".  Module-level so it compiles once per process.
 _IMPORT_ANY_RE = re.compile(
     r"import(?:"
     r"\s*(?P<named>\{[^}]+\})\s*"
@@ -242,6 +247,7 @@ _IMPORT_ANY_RE = re.compile(
     r"|\s+(?P<default>\w+)\s+"
     r")from\s*"
     r"""["'](?P<spec>@[^"']+)["']"""
+    r"""|import\s*["'](?P<side>@[^"']+)["']"""
 )
 
 
@@ -658,6 +664,7 @@ class AssetsBundle:
             "survey.survey_user_input_session_assets",
             "web_studio.report_assets",
             "web_studio.studio_assets",
+            "web_studio.studio_assets_dark",
             "web_studio.studio_assets_minimal",
             "web_tour.automatic",
             "web_tour.interactive",
@@ -703,6 +710,8 @@ class AssetsBundle:
                 "web.assets_emoji",
                 "web_tour.recorder",
                 "im_livechat.assets_livechat_support_tours",
+                "web_studio.studio_assets",
+                "web_studio.studio_assets_dark",
             ],
         }
     )
@@ -2005,11 +2014,12 @@ class AssetsBundle:
         ext_seen: set[str] = set()
         for asset in self.native_modules:
             # Single pass over each module's source: _IMPORT_ANY_RE matches the
-            # named / default / namespace import shapes in one finditer (was
-            # three separate full-source scans). The kind is read from whichever
-            # named group matched.
+            # named / default / namespace / bindingless-side-effect import shapes
+            # in one finditer. The kind is read from whichever named group
+            # matched; ``spec`` (binding+from) and ``side`` (side-effect) are
+            # mutually exclusive per match.
             for match in _IMPORT_ANY_RE.finditer(asset.raw_content):
-                specifier = match.group("spec")
+                specifier = match.group("spec") or match.group("side")
                 if specifier in ext_lib_names:
                     ext_seen.add(specifier)
                     continue
@@ -2019,7 +2029,13 @@ class AssetsBundle:
                     discovered.setdefault(specifier, set()).add("__default__")
                 elif match.group("star") is not None:
                     discovered.setdefault(specifier, set()).add("__star__")
-                else:  # named import — registers the specifier with no kind
+                else:
+                    # Named import OR bindingless side-effect import: register
+                    # the specifier with no kind. For a side-effect import the
+                    # shim still reads the source file's export surface, and the
+                    # side effect itself already ran in the parent bundle, so an
+                    # import-map entry to a valid (even export-only) shim is all
+                    # the child needs to resolve the specifier.
                     discovered.setdefault(specifier, set())
         return discovered, ext_seen
 


### PR DESCRIPTION
# [Task ID: 22867](https://agromarin.mx/odoo/project.task/22867)

## Problem
Studio failed to open in **both light and dark** after the native-ESM campaign. `web_studio`'s lazy bundles were registered in `ESM_BUNDLES` but **not** `DYNAMIC_ESM_BUNDLES`, so `/web/bundle` served them legacy and their esbuild `.esm.js` loaded as a classic `<script>` (`SyntaxError`). The bundles also re-included the whole `web.assets_backend`, and the native→legacy bridge ignored bindingless side-effect imports (`import "@addon/x";`), so a low-overlap child failed at runtime with *"Failed to resolve module specifier"*.

## Solution
- Register `web_studio.studio_assets` and `studio_assets_dark` as **low-overlap dynamic ESM children** of `web.assets_web` (and `studio_assets_dark` in `_ESM_ADDON_BUNDLES` to satisfy `_validate_esm_config`).
- Extend `_IMPORT_ANY_RE` with a bindingless side-effect branch so `_discover_bridge_specifiers` bridges `import "@addon/x";` too — single scan, benefits every low-overlap child, not just Studio.
- Reshape `web.assets_backend_dark` to **SCSS-only** (`web._assets_helpers` + `web._assets_backend_helpers`) so the dark child gets dark CSS without re-bundling backend JS.
- `web_hierarchy` self-provides its `hierarchy.variables.scss` anchor, since `web.assets_backend_dark` no longer includes `web.assets_backend`.

## Verification
- `curl /web/bundle/web_studio.studio_assets` and `…_dark` → `is_esm:true`, `event=bundled` (111 modules, was ~3053), no `event=failed`.
- Studio opens in **light AND dark** with no fatal console errors (`odoo-ui-tester` on a fresh clone of `marin190`).
- Regression test `web_enterprise:TestStudioEsmBundles` (3 tests) passes `post_install`.

> Cross-repo: lands together with enterprise PR maringuadarrama/enterprise#37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
